### PR TITLE
[FEAT] 강의 라우터(course.py) 및 서비스 로직(course_service.py) 생성

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -30,29 +30,14 @@ class Settings(BaseSettings):
 
     @property
     def database_url(self) -> str:
-        """PostgreSQL 연결 URL 구성"""
+        """비동기 PostgreSQL URL (asyncpg)"""
         return (
-            f"postgresql+psycopg2://{self.database_user}:"
+            f"postgresql+asyncpg://{self.database_user}:"
             f"{self.database_password}@{self.database_host}:"
             f"{self.database_port}/{self.database_name}"
         )
 
     # =====================================================
-    # Redis 캐시(주석 처리됨)
-    # =====================================================
-    # redis_host: str = "localhost"
-    # redis_port: int = 6379
-    # redis_db: int = 0
-    # redis_password: str = "your_redis_password"
-    # redis_timeout: int = 5
-    #
-    # @property
-    # def redis_url(self) -> str:
-    #     """Redis 연결 URL 구성"""
-    #     return (
-    #         f"redis://:{self.redis_password}@{self.redis_host}:"
-    #         f"{self.redis_port}/{self.redis_db}"
-    #     )
     # Redis 캐시
     # =====================================================
     redis_host: str = "localhost"

--- a/core/database.py
+++ b/core/database.py
@@ -1,78 +1,52 @@
-"""
-데이터베이스 연결 및 세션 관리
-
-SQLAlchemy를 사용한 PostgreSQL 연결과 Redis 연결을 관리합니다.
-"""
-
-from typing import Generator
-from sqlalchemy import create_engine, event
+from typing import AsyncGenerator
+from sqlalchemy.ext.asyncio import (
+    create_async_engine,
+    AsyncSession,
+    async_sessionmaker
+)
 from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import sessionmaker, Session
-from sqlalchemy.pool import QueuePool
-import redis
-from redis import Redis
+from sqlalchemy.pool import AsyncAdaptedQueuePool
+from sqlalchemy import event, text
+import redis.asyncio as redis
+from redis.asyncio import Redis
 import logging
 
 from core.config import settings
 
-# 로거 설정
 logger = logging.getLogger(__name__)
 
 # =====================================================
-# SQLAlchemy 엔진 생성 (PostgreSQL)
+# AsyncPG 엔진 생성
 # =====================================================
 
-# 데이터베이스 엔진 생성
-engine = create_engine(
+async_engine = create_async_engine(
     settings.database_url,
-    echo=settings.database_echo,  # SQL 쿼리 로깅 (개발 시 True)
-    poolclass=QueuePool,  # 연결 풀 사용
-    pool_size=settings.database_pool_size,  # 기본 연결 풀 크기
-    max_overflow=settings.database_max_overflow,  # 추가 연결 허용 수
-    pool_pre_ping=True,  # 연결 전 ping으로 유효성 검사
-    pool_recycle=3600,  # 1시간마다 연결 재사용 (메모리 누수 방지)
+    echo=settings.database_echo,
+    poolclass=AsyncAdaptedQueuePool,
+    pool_size=settings.database_pool_size,
+    max_overflow=settings.database_max_overflow,
+    pool_pre_ping=True,
+    pool_recycle=3600,
 )
 
-
-# SQLAlchemy 이벤트: 연결 시 타임존 설정
-@event.listens_for(engine, 'connect')
-def set_timezone(dbapi_conn, connection_record):
-    """
-    PostgreSQL 연결 시 타임존을 Asia/Seoul로 설정
-    """
-    cursor = dbapi_conn.cursor()
-    cursor.execute(f"SET TIME ZONE '{settings.timezone}'")
-    cursor.close()
-
-
-# 세션 로컬 클래스 생성
-SessionLocal = sessionmaker(
-    autocommit=False,  # 자동 커밋 비활성화 (명시적 커밋 필요)
-    autoflush=False,  # 자동 플러시 비활성화
-    bind=engine  # 위에서 생성한 엔진과 연결
+# 비동기 세션 메이커
+async_session_maker = async_sessionmaker(
+    async_engine,
+    class_=AsyncSession,
+    expire_on_commit=False,
+    autocommit=False,
+    autoflush=False,
 )
 
-# 모델 Base 클래스 생성
-# 모든 SQLAlchemy 모델은 이 Base를 상속받아야 함
 Base = declarative_base()
 
 
 # =====================================================
-# Redis 클라이언트 생성
+# Redis 비동기 클라이언트
 # =====================================================
 
-def get_redis_client() -> Redis:
-    """
-    Redis 클라이언트 인스턴스 반환
-    
-    캐싱, 세션 저장, 통계 데이터 저장 등에 사용합니다.
-    
-    Returns:
-        Redis: Redis 클라이언트 인스턴스
-    
-    Raises:
-        redis.ConnectionError: Redis 연결 실패 시
-    """
+async def get_redis_client() -> Redis:
+    """Redis 비동기 클라이언트 반환"""
     try:
         redis_client = redis.Redis(
             host=settings.redis_host,
@@ -80,15 +54,13 @@ def get_redis_client() -> Redis:
             db=settings.redis_db,
             password=settings.redis_password,
             socket_timeout=settings.redis_timeout,
-            decode_responses=True,  # 자동으로 bytes를 str로 변환
+            decode_responses=True,
             socket_connect_timeout=settings.redis_timeout,
-            health_check_interval=30,  # 30초마다 연결 상태 확인
+            health_check_interval=30,
         )
         
-        # Redis 연결 테스트
-        redis_client.ping()
+        await redis_client.ping()
         logger.info('Redis 연결 성공')
-        
         return redis_client
         
     except redis.ConnectionError as e:
@@ -96,134 +68,89 @@ def get_redis_client() -> Redis:
         raise
 
 
-# Redis 클라이언트 전역 인스턴스
-try:
-    redis_client = get_redis_client()
-except Exception as e:
-    logger.warning(f'Redis 초기화 실패, 캐싱 기능 비활성화: {e}')
-    redis_client = None
+# 전역 Redis 클라이언트 (앱 시작 시 초기화)
+redis_client: Redis | None = None
 
 
-# =====================================================
-# 데이터베이스 세션 의존성
-# =====================================================
-
-def get_db() -> Generator[Session, None, None]:
-    """
-    FastAPI 의존성으로 사용할 데이터베이스 세션 생성기
-    
-    요청마다 새로운 세션을 생성하고, 요청 종료 시 자동으로 닫습니다.
-    트랜잭션 관리를 위해 명시적으로 commit()을 호출해야 합니다.
-    
-    Yields:
-        Session: SQLAlchemy 데이터베이스 세션
-    
-    사용 예시:
-        @router.get('/users')
-        def get_users(db: Session = Depends(get_db)):
-            users = db.query(User).all()
-            return users
-    """
-    db = SessionLocal()
+async def init_redis():
+    """Redis 초기화 (startup 이벤트에서 호출)"""
+    global redis_client
     try:
-        yield db
-    finally:
-        db.close()
+        redis_client = await get_redis_client()
+    except Exception as e:
+        logger.warning(f'Redis 초기화 실패, 캐싱 기능 비활성화: {e}')
+        redis_client = None
+
+
+async def close_redis():
+    """Redis 연결 종료 (shutdown 이벤트에서 호출)"""
+    global redis_client
+    if redis_client:
+        await redis_client.close()
+        logger.info('Redis 연결 종료')
 
 
 # =====================================================
-# 데이터베이스 초기화
+# 비동기 DB 세션 의존성
 # =====================================================
 
-def init_db() -> None:
-    """
-    데이터베이스 테이블 생성
-    
-    Base를 상속받은 모든 모델의 테이블을 생성합니다.
-    주의: 프로덕션에서는 Alembic 마이그레이션을 사용해야 합니다.
-    
-    사용 예시:
-        # main.py
-        from core.database import init_db
-        
-        @app.on_event('startup')
-        async def startup():
-            init_db()
-    """
+async def get_db() -> AsyncGenerator[AsyncSession, None]:
+    """비동기 DB 세션 제공"""
+    async with async_session_maker() as session:
+        try:
+            yield session
+        finally:
+            await session.close()
+
+
+# =====================================================
+# DB 초기화
+# =====================================================
+
+async def init_db() -> None:
+    """데이터베이스 테이블 생성 (개발용)"""
     try:
-        # 모든 모델을 import해야 Base.metadata에 등록됨
-        # 여기서는 주석으로 표시하고, 실제로는 main.py에서 import
-        # from models import user, course, enrollment, payment, ...
-        
-        Base.metadata.create_all(bind=engine)
+        async with async_engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
         logger.info('데이터베이스 테이블 생성 완료')
-        
     except Exception as e:
         logger.error(f'데이터베이스 초기화 실패: {e}')
         raise
 
 
-def drop_db() -> None:
-    """
-    모든 데이터베이스 테이블 삭제
-    
-    주의: 개발 환경에서만 사용하세요!
-    모든 데이터가 삭제됩니다.
-    """
+async def drop_db() -> None:
+    """모든 테이블 삭제 (개발용)"""
     if settings.env == 'production':
-        raise RuntimeError(
-            '프로덕션 환경에서는 테이블 삭제가 금지되어 있습니다'
-        )
+        raise RuntimeError('프로덕션 환경에서는 테이블 삭제가 금지됩니다')
     
-    Base.metadata.drop_all(bind=engine)
+    async with async_engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
     logger.warning('모든 데이터베이스 테이블 삭제 완료')
 
 
 # =====================================================
-# 데이터베이스 연결 상태 확인
+# 헬스체크
 # =====================================================
 
-def check_db_connection() -> bool:
-    """
-    데이터베이스 연결 상태 확인
-    
-    헬스체크 엔드포인트에서 사용할수 있습니다.
-    
-    Returns:
-        bool: 연결 성공 시 True, 실패 시 False
-    
-    사용 예시:
-        @router.get('/health')
-        def health_check():
-            db_ok = check_db_connection()
-            return {'database': 'ok' if db_ok else 'error'}
-    """
+async def check_db_connection() -> bool:
+    """데이터베이스 연결 확인"""
     try:
-        db = SessionLocal()
-        # 간단한 쿼리로 연결 테스트
-        db.execute('SELECT 1')
-        db.close()
-        return True
-        
+        async with async_session_maker() as session:
+            await session.execute(text('SELECT 1'))
+            return True
     except Exception as e:
         logger.error(f'데이터베이스 연결 확인 실패: {e}')
         return False
 
 
-def check_redis_connection() -> bool:
-    """
-    Redis 연결 상태 확인
-    
-    Returns:
-        bool: 연결 성공 시 True, 실패 시 False
-    """
+async def check_redis_connection() -> bool:
+    """Redis 연결 확인"""
     if redis_client is None:
         return False
     
     try:
-        redis_client.ping()
+        await redis_client.ping()
         return True
-        
     except Exception as e:
         logger.error(f'Redis 연결 확인 실패: {e}')
         return False
@@ -233,44 +160,21 @@ def check_redis_connection() -> bool:
 # 트랜잭션 헬퍼
 # =====================================================
 
-class DatabaseTransaction:
-    """
-    컨텍스트 매니저를 사용한 트랜잭션 관리
-    
-    with 문으로 트랜잭션을 관리하여 자동 커밋/롤백을 수행합니다.
-    
-    사용 예시:
-        with DatabaseTransaction() as db:
-            user = User(email='test@test.com')
-            db.add(user)
-            # with 블록을 벗어나면 자동으로 commit
-            # 에러 발생 시 자동으로 rollback
-    """
+class AsyncDatabaseTransaction:
+    """비동기 트랜잭션 컨텍스트 매니저"""
     
     def __init__(self):
-        self.db: Session = SessionLocal()
+        self.session: AsyncSession | None = None
     
-    def __enter__(self) -> Session:
-        """컨텍스트 진입 시 세션 반환"""
-        return self.db
+    async def __aenter__(self) -> AsyncSession:
+        self.session = async_session_maker()
+        return self.session
     
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        """
-        컨텍스트 종료 시 커밋 또는 롤백
-        
-        Args:
-            exc_type: 예외 타입
-            exc_val: 예외 값
-            exc_tb: 예외 traceback
-        """
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
         if exc_type is not None:
-            # 예외 발생 시 롤백
-            self.db.rollback()
-            logger.error(
-                f'트랜잭션 롤백: {exc_type.__name__}: {exc_val}'
-            )
+            await self.session.rollback()
+            logger.error(f'트랜잭션 롤백: {exc_type.__name__}: {exc_val}')
         else:
-            # 정상 종료 시 커밋
-            self.db.commit()
+            await self.session.commit()
         
-        self.db.close()
+        await self.session.close()

--- a/core/database.py
+++ b/core/database.py
@@ -6,7 +6,7 @@ from sqlalchemy.ext.asyncio import (
 )
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.pool import AsyncAdaptedQueuePool
-from sqlalchemy import event, text
+from sqlalchemy import text
 import redis.asyncio as redis
 from redis.asyncio import Redis
 import logging

--- a/core/dependencies.py
+++ b/core/dependencies.py
@@ -1,24 +1,9 @@
-"""
-FastAPI 의존성 함수
-API 엔드포인트에서 사용할 공통 의존성 함수들을 정의합니다.
-
-주요 기능:
-- 사용자 인증 (JWT 토큰 검증)
-- 권한 확인 (일반 사용자, 관리자 등)
-- DB 세션 관리
-
-수정 사항 (Review Feedback 반영):
-1. 비동기 함수 내 DB 쿼리를 run_in_threadpool로 래핑하여 블로킹 방지
-2. get_current_user_optional에서 예상되는 오류만 명시적으로 처리
-3. 시간대 정보가 있는 datetime.now(timezone.utc) 사용
-"""
-
 from typing import Optional
 from datetime import datetime, timezone
 from fastapi import Depends, HTTPException, status
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
-from fastapi.concurrency import run_in_threadpool
-from sqlalchemy.orm import Session
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
 from jose import JWTError
 import logging
 
@@ -26,47 +11,20 @@ from core.security import decode_token
 from core.database import get_db
 from models.user import User
 
-# 로거 설정
 logger = logging.getLogger(__name__)
 
-# HTTPBearer 보안 스키마
-# Swagger에서 Authorization: Bearer {token} 형태로 표시됨
 security = HTTPBearer()
 
 
-# ============= 사용자 인증 의존성 =============
+# ============= 사용자 인증 =============
 
 async def get_current_user(
     credentials: HTTPAuthorizationCredentials = Depends(security),
-    db: Session = Depends(get_db)
+    db: AsyncSession = Depends(get_db)
 ) -> User:
-    """
-    현재 로그인한 사용자 정보 반환
-    
-    Authorization 헤더의 JWT 토큰을 검증하고 사용자 정보를 조회합니다.
-    
-    🔧 수정사항: DB 쿼리를 run_in_threadpool로 래핑하여 블로킹 방지
-    
-    Args:
-        credentials: HTTPBearer에서 자동으로 추출한 토큰 정보
-        db: 데이터베이스 세션
-    
-    Returns:
-        User: 현재 로그인한 사용자 객체
-    
-    Raises:
-        HTTPException 401: 토큰이 유효하지 않거나 만료됨
-        HTTPException 401: 사용자를 찾을 수 없음
-        HTTPException 403: 비활성화된 계정
-    
-    사용 예시:
-        @router.get("/my")
-        async def get_my_data(current_user: User = Depends(get_current_user)):
-            return {"user_id": current_user.id}
-    """
+    """현재 로그인한 사용자 반환"""
     token = credentials.credentials
     
-    # 1. 토큰 디코딩 및 검증
     payload = decode_token(token, token_type='access')
     
     if payload is None:
@@ -76,7 +34,6 @@ async def get_current_user(
             headers={"WWW-Authenticate": "Bearer"},
         )
     
-    # 2. 사용자 ID 추출
     user_id = payload.get('sub')
     if user_id is None:
         raise HTTPException(
@@ -85,12 +42,11 @@ async def get_current_user(
             headers={"WWW-Authenticate": "Bearer"},
         )
     
-    # 3. DB에서 사용자 조회 (비동기 처리)
-    # 🔧 수정: run_in_threadpool로 블로킹 방지
-    def _get_user_from_db():
-        return db.query(User).filter(User.id == user_id).first()
-    
-    user = await run_in_threadpool(_get_user_from_db)
+    # 비동기 쿼리
+    result = await db.execute(
+        select(User).where(User.id == user_id)
+    )
+    user = result.scalar_one_or_none()
     
     if user is None:
         raise HTTPException(
@@ -99,7 +55,6 @@ async def get_current_user(
             headers={"WWW-Authenticate": "Bearer"},
         )
     
-    # 4. 사용자 활성화 상태 확인
     if not user.is_active:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
@@ -112,246 +67,93 @@ async def get_current_user(
 async def get_current_active_user(
     current_user: User = Depends(get_current_user)
 ) -> User:
-    """
-    현재 활성화된 사용자 정보 반환
-    
-    get_current_user의 별칭 함수입니다.
-    이미 get_current_user에서 활성화 상태를 확인하므로,
-    이 함수는 명시적으로 "활성 사용자만"을 의미할 때 사용합니다.
-    
-    Args:
-        current_user: get_current_user에서 반환된 사용자
-    
-    Returns:
-        User: 활성화된 사용자 객체
-    
-    사용 예시:
-        @router.post("/payment")
-        async def create_payment(
-            current_user: User = Depends(get_current_active_user)
-        ):
-            # 활성 사용자만 결제 가능
-            pass
-    """
-    # get_current_user에서 이미 is_active를 확인하므로
-    # 추가 검증 없이 그대로 반환
+    """활성화된 사용자 반환"""
     return current_user
 
 
-# ============= 관리자 권한 의존성 =============
+# ============= 권한 확인 =============
 
 async def get_current_admin(
     current_user: User = Depends(get_current_user)
 ) -> User:
-    """
-    현재 로그인한 사용자가 관리자인지 확인
-    
-    일반 사용자가 관리자 전용 API에 접근하는 것을 방지합니다.
-    
-    Args:
-        current_user: get_current_user에서 반환된 사용자
-    
-    Returns:
-        User: 관리자 권한을 가진 사용자 객체
-    
-    Raises:
-        HTTPException 403: 관리자 권한이 없는 경우
-    
-    사용 예시:
-        @router.get("/admin/dashboard")
-        async def admin_dashboard(admin: User = Depends(get_current_admin)):
-            return {"message": "관리자 전용"}
-    """
+    """관리자 권한 확인"""
     if not current_user.is_admin:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="관리자 권한이 필요합니다"
         )
-    
     return current_user
 
 
 async def get_current_instructor(
     current_user: User = Depends(get_current_user)
 ) -> User:
-    """
-    현재 로그인한 사용자가 강사인지 확인
-    
-    Q&A 답변 작성 등 강사 전용 기능에 사용합니다.
-    관리자도 강사 권한을 가집니다.
-    
-    Args:
-        current_user: get_current_user에서 반환된 사용자
-    
-    Returns:
-        User: 강사 권한을 가진 사용자 객체
-    
-    Raises:
-        HTTPException 403: 강사 권한이 없는 경우
-    
-    사용 예시:
-        @router.post("/questions/{question_id}/comments")
-        async def create_answer(
-            instructor: User = Depends(get_current_instructor)
-        ):
-            # 강사/관리자만 답변 작성 가능
-            pass
-    """
-    # User 모델에 is_instructor 필드가 있다고 가정
-    # 없다면 role 필드나 다른 방식으로 체크
+    """강사 권한 확인"""
     if not (current_user.is_admin or getattr(current_user, 'is_instructor', False)):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="강사 또는 관리자 권한이 필요합니다"
         )
-    
     return current_user
 
 
-# ============= 선택적 인증 의존성 =============
+# ============= 선택적 인증 =============
 
 async def get_current_user_optional(
     credentials: Optional[HTTPAuthorizationCredentials] = Depends(
         HTTPBearer(auto_error=False)
     ),
-    db: Session = Depends(get_db)
+    db: AsyncSession = Depends(get_db)
 ) -> Optional[User]:
-    """
-    선택적으로 현재 사용자 정보 반환 (비로그인도 허용)
-    
-    로그인하지 않아도 접근 가능하지만,
-    로그인한 경우 추가 정보를 제공하는 API에 사용합니다.
-    
-    🔧 수정사항:
-    - 예상되는 오류(JWTError)만 명시적으로 처리
-    - 심각한 서버 오류는 로깅 후 재발생
-    - DB 쿼리 블로킹 방지
-    
-    Args:
-        credentials: HTTPBearer에서 추출한 토큰 (없을 수 있음)
-        db: 데이터베이스 세션
-    
-    Returns:
-        Optional[User]: 로그인한 경우 사용자 객체, 아니면 None
-    
-    사용 예시:
-        @router.get("/courses/{course_id}")
-        async def get_course(
-            course_id: int,
-            current_user: Optional[User] = Depends(get_current_user_optional)
-        ):
-            # 로그인 안 해도 강의 조회는 가능
-            # 단, 로그인했으면 수강 여부도 같이 보여줌
-            course = get_course_from_db(course_id)
-            
-            if current_user:
-                course.is_enrolled = check_enrollment(current_user.id, course_id)
-            
-            return course
-    """
+    """선택적 사용자 인증 (비로그인 허용)"""
     if credentials is None:
-        # 토큰이 없으면 None 반환 (에러 발생 안 함)
         return None
     
     try:
-        # 토큰이 있으면 검증 시도
         token = credentials.credentials
         payload = decode_token(token, token_type='access')
         
         if payload is None:
-            logger.info("유효하지 않은 토큰 (선택적 인증)")
             return None
         
         user_id = payload.get('sub')
         if user_id is None:
-            logger.warning("토큰에 사용자 ID 없음 (선택적 인증)")
             return None
         
-        # DB에서 사용자 조회 (비동기 처리)
-        # 🔧 수정: run_in_threadpool로 블로킹 방지
-        def _get_user_from_db():
-            return db.query(User).filter(User.id == user_id).first()
+        result = await db.execute(
+            select(User).where(User.id == user_id)
+        )
+        user = result.scalar_one_or_none()
         
-        user = await run_in_threadpool(_get_user_from_db)
-        
-        if user is None:
-            logger.warning(f"사용자를 찾을 수 없음: user_id={user_id}")
-            return None
-        
-        if not user.is_active:
-            logger.info(f"비활성 사용자: user_id={user_id}")
+        if user is None or not user.is_active:
             return None
         
         return user
         
-    except JWTError as e:
-        # 🔧 수정: JWT 관련 오류만 명시적으로 처리
-        logger.info(f"JWT 검증 실패 (선택적 인증): {e}")
+    except (JWTError, HTTPException):
         return None
-    
-    except HTTPException:
-        # HTTP 예외는 그냥 None 반환
-        return None
-    
     except Exception as e:
-        # 🔧 수정: 예상치 못한 심각한 오류는 로깅 후 재발생
-        logger.error(
-            f"선택적 인증 중 예상치 못한 오류 발생: {e}",
-            exc_info=True
-        )
-        # 심각한 서버 오류는 숨기지 않고 상위로 전파
-        # 운영 환경에서는 None을 반환하도록 설정할 수도 있음
+        logger.error(f'선택적 인증 오류: {e}', exc_info=True)
         return None
 
 
-# ============= 강의 접근 권한 확인 의존성 =============
+# ============= 수강 권한 확인 =============
 
 async def verify_enrollment_access(
     course_id: int,
     current_user: User = Depends(get_current_user),
-    db: Session = Depends(get_db)
+    db: AsyncSession = Depends(get_db)
 ):
-    """
-    사용자가 특정 강의에 접근 권한이 있는지 확인
+    """수강 권한 확인"""
+    from models.progress import Enrollment
     
-    강의 영상 시청, 미션 제출 등에 사용합니다.
-    
-    🔧 수정사항:
-    - DB 쿼리 블로킹 방지
-    - datetime.now(timezone.utc) 사용으로 시간대 불일치 해결
-    
-    Args:
-        course_id: 확인할 강의 ID
-        current_user: 현재 로그인한 사용자
-        db: 데이터베이스 세션
-    
-    Returns:
-        Enrollment: 수강 등록 객체
-    
-    Raises:
-        HTTPException 403: 수강 등록하지 않은 강의
-        HTTPException 410: 수강 기간 만료
-    
-    사용 예시:
-        @router.get("/lectures/{lecture_id}")
-        async def get_lecture(
-            lecture_id: int,
-            enrollment = Depends(verify_enrollment_access)
-        ):
-            # 수강 등록된 사용자만 강의 영상 조회 가능
-            pass
-    """
-    from models.enrollment import Enrollment
-    
-    # 수강 등록 확인 (비동기 처리)
-    # 🔧 수정: run_in_threadpool로 블로킹 방지
-    def _get_enrollment():
-        return db.query(Enrollment).filter(
+    result = await db.execute(
+        select(Enrollment).where(
             Enrollment.user_id == current_user.id,
             Enrollment.course_id == course_id
-        ).first()
-    
-    enrollment = await run_in_threadpool(_get_enrollment)
+        )
+    )
+    enrollment = result.scalar_one_or_none()
     
     if not enrollment:
         raise HTTPException(
@@ -359,23 +161,11 @@ async def verify_enrollment_access(
             detail="수강 등록이 필요합니다"
         )
     
-    # 🔧 수정: timezone.utc 사용으로 시간대 불일치 해결
-    # enrollment.expired_at은 DB에 UTC로 저장되어 있다고 가정
     current_time_utc = datetime.now(timezone.utc)
+    expired_at_utc = enrollment.expired_at.replace(tzinfo=timezone.utc) \
+        if enrollment.expired_at.tzinfo is None else enrollment.expired_at
     
-    # expired_at이 naive datetime인 경우 UTC로 간주
-    if enrollment.expired_at.tzinfo is None:
-        # naive datetime을 aware datetime으로 변환
-        expired_at_utc = enrollment.expired_at.replace(tzinfo=timezone.utc)
-    else:
-        expired_at_utc = enrollment.expired_at
-    
-    # 수강 기간 확인
     if expired_at_utc < current_time_utc:
-        logger.info(
-            f"수강 기간 만료: user_id={current_user.id}, "
-            f"course_id={course_id}, expired_at={expired_at_utc}"
-        )
         raise HTTPException(
             status_code=status.HTTP_410_GONE,
             detail="수강 기간이 만료되었습니다"
@@ -384,49 +174,16 @@ async def verify_enrollment_access(
     return enrollment
 
 
-# ============= 리소스 소유권 확인 의존성 =============
+# ============= 리소스 소유권 확인 =============
 
 async def verify_resource_owner(
     resource_user_id: int,
     current_user: User = Depends(get_current_user)
 ) -> User:
-    """
-    사용자가 해당 리소스의 소유자인지 확인
-    
-    본인의 질문/댓글만 수정/삭제할 수 있도록 제한합니다.
-    관리자는 모든 리소스에 접근 가능합니다.
-    
-    Args:
-        resource_user_id: 리소스를 생성한 사용자 ID
-        current_user: 현재 로그인한 사용자
-    
-    Returns:
-        User: 검증된 사용자 객체
-    
-    Raises:
-        HTTPException 403: 본인의 리소스가 아닌 경우
-    
-    사용 예시:
-        @router.delete("/questions/{question_id}")
-        async def delete_question(
-            question_id: int,
-            current_user: User = Depends(get_current_user),
-            db: Session = Depends(get_db)
-        ):
-            question = db.query(Question).get(question_id)
-            
-            # 소유권 확인
-            await verify_resource_owner(question.user_id, current_user)
-            
-            # 삭제 진행
-            db.delete(question)
-            db.commit()
-    """
-    # 관리자는 모든 리소스에 접근 가능
+    """리소스 소유권 확인"""
     if current_user.is_admin:
         return current_user
     
-    # 본인의 리소스가 아니면 403 에러
     if current_user.id != resource_user_id:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
@@ -436,42 +193,13 @@ async def verify_resource_owner(
     return current_user
 
 
-# ============= 페이지네이션 의존성 =============
+# ============= 페이지네이션 =============
 
 def get_pagination_params(
     page: int = 1,
     page_size: int = 20
 ):
-    """
-    페이지네이션 파라미터 검증 및 반환
-    
-    Args:
-        page: 페이지 번호 (1부터 시작)
-        page_size: 페이지 크기 (최대 100)
-    
-    Returns:
-        dict: {"skip": int, "limit": int, "page": int, "page_size": int}
-    
-    Raises:
-        HTTPException 422: 잘못된 페이지 파라미터
-    
-    사용 예시:
-        @router.get("/courses")
-        async def get_courses(
-            pagination = Depends(get_pagination_params),
-            db: Session = Depends(get_db)
-        ):
-            skip = pagination["skip"]
-            limit = pagination["limit"]
-            
-            # DB 쿼리 (비동기 처리)
-            def _get_courses():
-                return db.query(Course).offset(skip).limit(limit).all()
-            
-            courses = await run_in_threadpool(_get_courses)
-            
-            return courses
-    """
+    """페이지네이션 파라미터 검증"""
     if page < 1:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
@@ -494,53 +222,21 @@ def get_pagination_params(
     }
 
 
-# ============= 강의별 접근 권한 확인 (세밀한 제어) =============
+# ============= 강의 접근 권한 확인 =============
 
 async def verify_lecture_access(
     lecture_id: int,
     current_user: User = Depends(get_current_user),
-    db: Session = Depends(get_db)
+    db: AsyncSession = Depends(get_db)
 ):
-    """
-    사용자가 특정 강의(Lecture)에 접근 권한이 있는지 확인
+    """강의 영상 접근 권한 확인"""
+    from models.course import Lecture
+    from models.progress import Enrollment
     
-    강의 → 챕터 → 강의(Lecture) 계층 구조에서
-    개별 강의 영상에 대한 접근 권한을 확인합니다.
-    
-    🔧 수정사항:
-    - DB 쿼리 블로킹 방지
-    - 시간대 정보가 있는 UTC 시간 사용
-    
-    Args:
-        lecture_id: 확인할 강의 ID
-        current_user: 현재 로그인한 사용자
-        db: 데이터베이스 세션
-    
-    Returns:
-        tuple: (Lecture, Enrollment)
-    
-    Raises:
-        HTTPException 404: 강의를 찾을 수 없음
-        HTTPException 403: 수강 등록하지 않은 강의
-        HTTPException 410: 수강 기간 만료
-    
-    사용 예시:
-        @router.get("/lectures/{lecture_id}/video")
-        async def get_lecture_video(
-            lecture_id: int,
-            lecture_enrollment = Depends(verify_lecture_access)
-        ):
-            lecture, enrollment = lecture_enrollment
-            return {"video_url": lecture.video_url}
-    """
-    from models.lecture import Lecture
-    from models.enrollment import Enrollment
-    
-    # 강의 조회 (비동기 처리)
-    def _get_lecture():
-        return db.query(Lecture).filter(Lecture.id == lecture_id).first()
-    
-    lecture = await run_in_threadpool(_get_lecture)
+    result = await db.execute(
+        select(Lecture).where(Lecture.id == lecture_id)
+    )
+    lecture = result.scalar_one_or_none()
     
     if not lecture:
         raise HTTPException(
@@ -548,18 +244,15 @@ async def verify_lecture_access(
             detail="강의를 찾을 수 없습니다"
         )
     
-    # 강의가 속한 코스 ID 가져오기
-    # Lecture → Chapter → Course 관계 탐색
     course_id = lecture.chapter.course_id
     
-    # 수강 등록 확인 (비동기 처리)
-    def _get_enrollment():
-        return db.query(Enrollment).filter(
+    result = await db.execute(
+        select(Enrollment).where(
             Enrollment.user_id == current_user.id,
             Enrollment.course_id == course_id
-        ).first()
-    
-    enrollment = await run_in_threadpool(_get_enrollment)
+        )
+    )
+    enrollment = result.scalar_one_or_none()
     
     if not enrollment:
         raise HTTPException(
@@ -567,13 +260,9 @@ async def verify_lecture_access(
             detail="수강 등록이 필요합니다"
         )
     
-    # 수강 기간 확인 (UTC 기준)
     current_time_utc = datetime.now(timezone.utc)
-    
-    if enrollment.expired_at.tzinfo is None:
-        expired_at_utc = enrollment.expired_at.replace(tzinfo=timezone.utc)
-    else:
-        expired_at_utc = enrollment.expired_at
+    expired_at_utc = enrollment.expired_at.replace(tzinfo=timezone.utc) \
+        if enrollment.expired_at.tzinfo is None else enrollment.expired_at
     
     if expired_at_utc < current_time_utc:
         raise HTTPException(
@@ -582,6 +271,3 @@ async def verify_lecture_access(
         )
     
     return lecture, enrollment
-
-
-# TODO: Check DB session closing logic (PR 임시 생성용)

--- a/routers/course.py
+++ b/routers/course.py
@@ -29,10 +29,9 @@ router = APIRouter(prefix="/courses", tags=["강의"])
     summary="강의 필터링 메타데이터 조회",
     responses={200: {"description": "성공"}, **COURSE_LIST_RESPONSES}
 )
-async def get_course_metadata(db: AsyncSession = Depends(get_db)):
+async def get_course_metadata():
     """강의 메타데이터 조회 (카테고리, 난이도, 가격 유형 등)"""
-    service = CourseService(db)
-    return await service.get_course_metadata()
+    return CourseService.get_course_metadata()
 
 
 @router.get(

--- a/routers/course.py
+++ b/routers/course.py
@@ -48,7 +48,14 @@ async def get_courses(
     """강의 목록 조회 (필터링, 검색, 페이지네이션)"""
     service = CourseService(db)
     user_id = current_user.id if current_user else None
-    return await service.get_courses(params, user_id)
+    result = await service.get_courses(params, user_id)
+    return PaginatedResponse[CourseResponse](
+        total=result.total,
+        page=result.page,
+        page_size=result.page_size,
+        total_pages=result.total_pages,
+        items=result.items
+    )
 
 
 @router.get(

--- a/routers/course.py
+++ b/routers/course.py
@@ -3,9 +3,9 @@
 강의 목록 조회, 상세 조회, 챕터/강의 영상 조회 등을 처리합니다.
 """
 
-from fastapi import APIRouter, Depends, status
+from fastapi import APIRouter, Depends
 from typing import List, Optional
-from schemas.common import MessageResponse, PaginatedResponse
+from schemas.common import PaginatedResponse
 from schemas.course import (
     CourseResponse, CourseDetailResponse,
     CourseListParams, 
@@ -13,7 +13,6 @@ from schemas.course import (
     LectureResponse, CourseMetadataResponse
 )
 from exceptions.responses import (
-    READ_RESPONSES,
     COURSE_LIST_RESPONSES,
     COURSE_DETAIL_RESPONSES,
     CHAPTER_DETAIL_RESPONSES,      

--- a/routers/course.py
+++ b/routers/course.py
@@ -1,10 +1,7 @@
-"""
-강의 API 라우터
-강의 목록 조회, 상세 조회, 챕터/강의 영상 조회 등을 처리합니다.
-"""
-
 from fastapi import APIRouter, Depends
 from typing import List, Optional
+from sqlalchemy.ext.asyncio import AsyncSession
+
 from schemas.common import PaginatedResponse
 from schemas.course import (
     CourseResponse, CourseDetailResponse,
@@ -19,381 +16,128 @@ from exceptions.responses import (
     LECTURE_LIST_RESPONSES,          
     LECTURE_DETAIL_RESPONSES,        
 )
-from core.dependencies import get_current_user_optional, get_current_user
+from core.dependencies import get_current_user_optional, get_current_user, get_db
 from models.user import User
+from services.course_service import CourseService
 
 router = APIRouter(prefix="/courses", tags=["강의"])
 
-
-# ============= 강의 검색 API =============
 
 @router.get(
     "/metadata",
     response_model=CourseMetadataResponse,
     summary="강의 필터링 메타데이터 조회",
-    description="강의 검색 및 필터링에 사용할 수 있는 카테고리, 난이도, 가격 유형 등의 메타데이터를 조회합니다.",
-    responses={
-        200: {"description": "메타데이터 조회 성공"},
-        **COURSE_LIST_RESPONSES
-    }
+    responses={200: {"description": "성공"}, **COURSE_LIST_RESPONSES}
 )
-async def get_course_metadata():
-    """
-    # 강의 메타데이터 조회 API
-    
-    강의 목록 필터링에 사용할 메타데이터를 반환합니다.
-    
-    ## 응답
-    - 200: 메타데이터 조회 성공
-    
-    ## 반환 정보
-    - **categories**: 카테고리 목록 (프론트엔드, 백엔드, 데이터분석, AI, 디자인, 기타)
-    - **course_types**: 강의 유형 (VOD, 부스트캠프, KDC)
-    - **difficulties**: 난이도 (beginner, intermediate, advanced)
-    - **price_types**: 가격 유형 (free, paid, national_support)
-    
-    ## 사용 사례
-    - 강의 목록 페이지의 필터 UI 구성
-    - 검색 필터 옵션 제공
-    
-    ## 참고
-    - 인증 불필요 (공개 API)
-    """
-    pass
+async def get_course_metadata(db: AsyncSession = Depends(get_db)):
+    """강의 메타데이터 조회 (카테고리, 난이도, 가격 유형 등)"""
+    service = CourseService(db)
+    return await service.get_course_metadata()
 
-
-# ============= 강의 API =============
 
 @router.get(
     "",
     response_model=PaginatedResponse[CourseResponse],
     summary="강의 목록 조회",
-    description="전체 강의 목록을 조회합니다. 카테고리, 난이도, 가격 유형 등으로 필터링할 수 있습니다.",
-    responses={
-        200: {"description": "강의 목록 조회 성공"},
-        **COURSE_LIST_RESPONSES
-    }
+    responses={200: {"description": "성공"}, **COURSE_LIST_RESPONSES}
 )
-async def get_courses(params: CourseListParams = Depends()):
-    """
-    # 강의 목록 조회 API
-    
-    조건에 따라 강의 목록을 조회합니다.
-    
-    ## 쿼리 파라미터
-    - **category_type**: 카테고리 필터 (frontend/backend/data_analysis/ai/design/other)
-    - **difficulty**: 난이도 필터 (beginner/intermediate/advanced)
-    - **price_type**: 가격 유형 필터 (free/paid/national_support)
-    - **keyword**: 검색 키워드 (강의명, 설명에서 검색)
-    - **is_published**: 공개 여부 (기본값: true, 관리자는 false 가능)
-    - **page**: 페이지 번호 (기본값: 1)
-    - **page_size**: 페이지 크기 (기본값: 20, 최대: 100)
-    
-    ## 응답
-    - 200: 강의 목록 조회 성공
-    - 422: 입력값 유효성 검사 실패
-    
-    ## 정렬
-    - 기본: 최신 생성순
-    
-    ## 예시
-    - 프론트엔드 초급 강의: `?category_type=frontend&difficulty=beginner`
-    - 무료 강의: `?price_type=free`
-    - 키워드 검색: `?keyword=React`
-    
-    ## 참고
-    - 인증 불필요 (공개 API)
-    """
-    pass
+async def get_courses(
+    params: CourseListParams = Depends(),
+    db: AsyncSession = Depends(get_db),
+    current_user: Optional[User] = Depends(get_current_user_optional)
+):
+    """강의 목록 조회 (필터링, 검색, 페이지네이션)"""
+    service = CourseService(db)
+    user_id = current_user.id if current_user else None
+    return await service.get_courses(params, user_id)
 
 
 @router.get(
     "/{course_id}",
     response_model=CourseDetailResponse,
     summary="강의 상세 조회",
-    description="특정 강의의 상세 정보를 조회합니다. 챕터와 강의 영상 목록이 포함됩니다.",
-    responses={
-        200: {"description": "강의 상세 조회 성공"},
-        **COURSE_DETAIL_RESPONSES
-    }
+    responses={200: {"description": "성공"}, **COURSE_DETAIL_RESPONSES}
 )
 async def get_course(
     course_id: int,
+    db: AsyncSession = Depends(get_db),
     current_user: Optional[User] = Depends(get_current_user_optional)
 ):
-    """
-    # 강의 상세 조회 API
-    
-    강의의 상세 정보와 커리큘럼을 조회합니다.
-    
-    ## 경로 파라미터
-    - **course_id**: 강의 ID
-    
-    ## 응답
-    - 200: 강의 정보 조회 성공
-    - 404: 강의를 찾을 수 없음
-    
-    ## 반환 정보
-    - 기본 정보: 제목, 설명, 강사, 난이도, 가격 등
-    - 커리큘럼: 전체 챕터 및 강의 영상 목록
-    - 수강 정보: 수강 여부, 진행률 (로그인 시)
-    - FAQ: 자주 묻는 질문
-    
-    ## 참고
-    - 선택적 인증 (로그인 안 해도 조회 가능)
-    - 로그인한 사용자의 경우 수강 여부와 진행률 정보가 포함됩니다
-    - 비공개 강의는 관리자만 조회 가능합니다
-    """
-    pass
+    """강의 상세 정보 조회 (챕터, 강의 영상 포함)"""
+    service = CourseService(db)
+    user_id = current_user.id if current_user else None
+    return await service.get_course_by_id(course_id, user_id)
 
 
 @router.get(
     "/{course_id}/chapters",
     response_model=List[ChapterWithLectures],
     summary="챕터 목록 조회",
-    description="특정 강의의 전체 챕터 목록을 조회합니다.",
-    responses={
-        200: {"description": "챕터 목록 조회 성공"},
-        **CHAPTER_DETAIL_RESPONSES
-    }
+    responses={200: {"description": "성공"}, **CHAPTER_DETAIL_RESPONSES}
 )
 async def get_chapters(
     course_id: int,
+    db: AsyncSession = Depends(get_db),
     current_user: Optional[User] = Depends(get_current_user_optional)
 ):
-    """
-    # 챕터 목록 조회 API
-    
-    강의의 전체 챕터와 각 챕터의 강의 영상을 조회합니다.
-    
-    ## 경로 파라미터
-    - **course_id**: 강의 ID
-    
-    ## 응답
-    - 200: 챕터 목록 조회 성공
-    - 404: 강의를 찾을 수 없음
-    
-    ## 반환 정보
-    - 챕터 정보: 제목, 설명, 순서, 총 시간
-    - 강의 영상 목록: 각 챕터에 포함된 강의 영상 정보
-    - 학습 진행 상태 (로그인 시): 완료 여부, 마지막 시청 위치 등
-    
-    ## 참고
-    - 선택적 인증 (로그인 안 해도 조회 가능)
-    """
-    pass
+    """강의의 전체 챕터 목록 조회"""
+    service = CourseService(db)
+    course_detail = await service.get_course_by_id(course_id, None)
+    return course_detail.chapters
 
 
 @router.get(
     "/{course_id}/chapters/{chapter_id}",
     response_model=ChapterWithLectures,
     summary="챕터 상세 조회",
-    description="특정 챕터의 상세 정보와 강의 영상 목록을 조회합니다.",
-    responses={
-        200: {"description": "챕터 상세 조회 성공"},
-        **COURSE_DETAIL_RESPONSES,
-        404: {
-            "description": "강의 또는 챕터를 찾을 수 없음",
-            "content": {
-                "application/json": {
-                    "examples": {
-                        "course_not_found": {
-                            "value": {
-                                "error": "COURSE_NOT_FOUND",
-                                "detail": "강의를 찾을 수 없습니다"
-                            }
-                        },
-                        "chapter_not_found": {
-                            "value": {
-                                "error": "CHAPTER_NOT_FOUND",
-                                "detail": "챕터를 찾을 수 없습니다"
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
+    responses={200: {"description": "성공"}, **COURSE_DETAIL_RESPONSES}
 )
 async def get_chapter(
     course_id: int,
     chapter_id: int,
+    db: AsyncSession = Depends(get_db),
     current_user: Optional[User] = Depends(get_current_user_optional)
 ):
-    """
-    # 챕터 상세 조회 API
-    
-    특정 챕터의 상세 정보를 조회합니다.
-    
-    ## 경로 파라미터
-    - **course_id**: 강의 ID
-    - **chapter_id**: 챕터 ID
-    
-    ## 응답
-    - 200: 챕터 정보 조회 성공
-    - 404: 강의 또는 챕터를 찾을 수 없음
-    
-    ## 반환 정보
-    - 챕터 기본 정보
-    - 챕터에 포함된 모든 강의 영상
-    - 각 강의의 학습 진행 상태 (로그인 시)
-    
-    ## 참고
-    - 선택적 인증 (로그인 안 해도 조회 가능)
-    """
-    pass
+    """특정 챕터의 상세 정보 조회"""
+    service = CourseService(db)
+    return await service.get_chapter_by_id(course_id, chapter_id)
 
 
 @router.get(
     "/{course_id}/chapters/{chapter_id}/lectures",
     response_model=List[LectureResponse],
     summary="강의 영상 목록 조회",
-    description="특정 챕터의 강의 영상 목록을 조회합니다.",
-    responses={
-        200: {"description": "강의 영상 목록 조회 성공"},
-        **LECTURE_LIST_RESPONSES,
-        404: {
-            "description": "강의 또는 챕터를 찾을 수 없음",
-            "content": {
-                "application/json": {
-                    "examples": {
-                        "course_not_found": {
-                            "value": {
-                                "error": "COURSE_NOT_FOUND",
-                                "detail": "강의를 찾을 수 없습니다"
-                            }
-                        },
-                        "chapter_not_found": {
-                            "value": {
-                                "error": "CHAPTER_NOT_FOUND",
-                                "detail": "챕터를 찾을 수 없습니다"
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
+    responses={200: {"description": "성공"}, **LECTURE_LIST_RESPONSES}
 )
 async def get_lectures(
     course_id: int,
     chapter_id: int,
+    db: AsyncSession = Depends(get_db),
     current_user: Optional[User] = Depends(get_current_user_optional)
 ):
-    """
-    # 강의 영상 목록 조회 API
-    
-    챕터에 속한 강의 영상들을 조회합니다.
-    
-    ## 경로 파라미터
-    - **course_id**: 강의 ID
-    - **chapter_id**: 챕터 ID
-    
-    ## 응답
-    - 200: 강의 영상 목록 조회 성공
-    - 404: 강의 또는 챕터를 찾을 수 없음
-    
-    ## 반환 정보
-    - 강의 영상 기본 정보: 제목, 설명, 재생 시간 등
-    - 동영상 정보: URL, 타입 (VOD/유튜브)
-    - 학습 진행 정보 (로그인 시): 완료 여부, 시청 시간, 마지막 위치
-    
-    ## 참고
-    - 선택적 인증 (로그인 안 해도 조회 가능)
-    """
-    pass
+    """챕터의 강의 영상 목록 조회"""
+    service = CourseService(db)
+    return await service.get_lectures_by_chapter(course_id, chapter_id)
 
 
 @router.get(
     "/{course_id}/chapters/{chapter_id}/lectures/{lecture_id}",
     response_model=LectureResponse,
     summary="강의 영상 상세 조회",
-    description="특정 강의 영상의 상세 정보를 조회합니다.",
-    responses={
-        200: {"description": "강의 영상 상세 조회 성공"},
-        **LECTURE_DETAIL_RESPONSES,
-        403: {
-            "description": "수강 권한 없음",
-            "content": {
-                "application/json": {
-                    "example": {
-                        "error": "ENROLLMENT_REQUIRED",
-                        "detail": "수강 등록이 필요합니다"
-                    }
-                }
-            }
-        },
-        404: {
-            "description": "강의, 챕터 또는 강의 영상을 찾을 수 없음",
-            "content": {
-                "application/json": {
-                    "examples": {
-                        "course_not_found": {
-                            "value": {
-                                "error": "COURSE_NOT_FOUND",
-                                "detail": "강의를 찾을 수 없습니다"
-                            }
-                        },
-                        "chapter_not_found": {
-                            "value": {
-                                "error": "CHAPTER_NOT_FOUND",
-                                "detail": "챕터를 찾을 수 없습니다"
-                            }
-                        },
-                        "lecture_not_found": {
-                            "value": {
-                                "error": "LECTURE_NOT_FOUND",
-                                "detail": "강의 영상을 찾을 수 없습니다"
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        410: {
-            "description": "수강 기간 만료",
-            "content": {
-                "application/json": {
-                    "example": {
-                        "error": "ENROLLMENT_EXPIRED",
-                        "detail": "수강 기간이 만료되었습니다"
-                    }
-                }
-            }
-        }
-    }
+    responses={200: {"description": "성공"}, **LECTURE_DETAIL_RESPONSES}
 )
 async def get_lecture(
     course_id: int,
     chapter_id: int,
     lecture_id: int,
+    db: AsyncSession = Depends(get_db),
     current_user: User = Depends(get_current_user)
 ):
-    """
-    # 강의 영상 상세 조회 API
-    
-    특정 강의 영상의 상세 정보를 조회합니다.
-    
-    ## 경로 파라미터
-    - **course_id**: 강의 ID
-    - **chapter_id**: 챕터 ID
-    - **lecture_id**: 강의 영상 ID
-    
-    ## 응답
-    - 200: 강의 영상 정보 조회 성공
-    - 401: 인증되지 않은 사용자
-    - 403: 수강 권한 없음
-    - 404: 강의, 챕터 또는 강의 영상을 찾을 수 없음
-    - 410: 수강 기간 만료
-    
-    ## 반환 정보
-    - 강의 영상 상세 정보
-    - 동영상 스트리밍 URL
-    - 학습 진행 정보: 완료 여부, 시청 시간, 마지막 시청 위치
-    
-    ## 참고
-    - 인증 필요 (로그인 필수)
-    - 수강 등록된 사용자만 접근 가능합니다
-    - 수강 기간이 만료된 경우 접근이 제한됩니다
-    """
-    pass
+    """특정 강의 영상의 상세 정보 조회 (인증 필요)"""
+    service = CourseService(db)
+    return await service.get_lecture_by_id(
+        course_id, 
+        chapter_id, 
+        lecture_id, 
+        current_user.id
+    )

--- a/routers/course.py
+++ b/routers/course.py
@@ -95,8 +95,7 @@ async def get_chapters(
 async def get_chapter(
     course_id: int,
     chapter_id: int,
-    db: AsyncSession = Depends(get_db),
-    current_user: Optional[User] = Depends(get_current_user_optional)
+    db: AsyncSession = Depends(get_db)
 ):
     """특정 챕터의 상세 정보 조회"""
     service = CourseService(db)

--- a/services/course_service.py
+++ b/services/course_service.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Dict
+from typing import List, Optional
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select, func, or_
 from sqlalchemy.orm import selectinload

--- a/services/course_service.py
+++ b/services/course_service.py
@@ -48,7 +48,7 @@ class CourseService:
                 Enrollment.course_id,
                 func.count(Enrollment.id).label('enrollment_count')
             )
-            .where(Enrollment.is_active == True)
+            .where(Enrollment.is_active)
             .group_by(Enrollment.course_id)
             .subquery()
         )

--- a/services/course_service.py
+++ b/services/course_service.py
@@ -1,17 +1,11 @@
-"""
-Course Service
-강의 관련 비즈니스 로직
-
-"""
-
-from typing import List, Optional, Tuple
-from sqlalchemy.orm import Session, joinedload
-from sqlalchemy import func, or_, and_
+from typing import List, Optional, Dict
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select, func, or_
+from sqlalchemy.orm import selectinload
 import math
 
-from models.course import Course, Chapter, Lecture, CategoryType, Difficulty, PriceType
-from models.progress import Enrollment
-from models.progress import Progress
+from models.course import Course, Chapter, Lecture, CategoryType, Difficulty, PriceType, CourseType
+from models.progress import Enrollment, Progress
 from schemas.course import (
     CourseListParams,
     CourseResponse,
@@ -34,104 +28,85 @@ from exceptions.base import (
 
 
 class CourseService:
-    """강의 관련 비즈니스 로직을 처리하는 서비스 클래스"""
+    """강의 관련 비즈니스 로직 (완전 비동기)"""
     
-    def __init__(self, db: Session):
-        """
-        서비스 초기화
-        
-        Args:
-            db: 데이터베이스 세션
-        """
+    def __init__(self, db: AsyncSession):
         self.db = db
     
-    # ==================== 강의 목록/상세 조회 ====================
+    # ==================== 강의 목록/상세 ====================
     
-    def get_courses(
+    async def get_courses(
         self,
         params: CourseListParams,
         user_id: Optional[int] = None
     ) -> CoursePaginatedResponse:
-        """
-        강의 목록 조회 (필터링, 페이지네이션, 검색)
+        """강의 목록 조회 (필터링, 페이지네이션, 검색)"""
         
-        Args:
-            params: 필터 파라미터 (카테고리, 난이도, 가격 타입, 키워드 등)
-            user_id: 현재 로그인한 사용자 ID (선택사항, 수강 여부 확인용)
+        # 서브쿼리: 강의별 수강 인원
+        enrollment_subquery = (
+            select(
+                Enrollment.course_id,
+                func.count(Enrollment.id).label('enrollment_count')
+            )
+            .where(Enrollment.is_active == True)
+            .group_by(Enrollment.course_id)
+            .subquery()
+        )
         
-        Returns:
-            CoursePaginatedResponse: 페이지네이션된 강의 목록
-        """
-        # 기본 쿼리 생성
-        query = self.db.query(Course)
+        # 메인 쿼리
+        query = (
+            select(
+                Course,
+                func.coalesce(enrollment_subquery.c.enrollment_count, 0).label('enrollment_count')
+            )
+            .outerjoin(
+                enrollment_subquery,
+                Course.id == enrollment_subquery.c.course_id
+            )
+        )
         
-        # === 필터링 ===
-        
-        # 1. 카테고리 필터
+        # 필터링
         if params.category_type:
-            query = query.filter(Course.category_type == params.category_type)
+            query = query.where(Course.category_type == params.category_type)
         
-        # 2. 난이도 필터
         if params.difficulty:
-            query = query.filter(Course.difficulty == params.difficulty)
+            query = query.where(Course.difficulty == params.difficulty)
         
-        # 3. 가격 타입 필터
         if params.price_type:
-            query = query.filter(Course.price_type == params.price_type)
+            query = query.where(Course.price_type == params.price_type)
         
-        # 4. 공개 여부 필터 (기본값: 공개된 강의만)
         if params.is_published is not None:
-            query = query.filter(Course.is_published == params.is_published)
+            query = query.where(Course.is_published == params.is_published)
         
-        # 5. 키워드 검색 (강의명, 강의 설명)
         if params.keyword:
             keyword_filter = or_(
                 Course.title.ilike(f'%{params.keyword}%'),
                 Course.description.ilike(f'%{params.keyword}%')
             )
-            query = query.filter(keyword_filter)
+            query = query.where(keyword_filter)
         
-        # === 정렬 ===
-        # 최신순 정렬 (생성일 기준 내림차순)
+        # 정렬
         query = query.order_by(Course.created_at.desc())
         
-        # === 전체 개수 계산 ===
-        total = query.count()
+        # 전체 개수
+        count_query = select(func.count()).select_from(query.subquery())
+        total_result = await self.db.execute(count_query)
+        total = total_result.scalar()
         
-        # === 페이지네이션 ===
+        # 페이지네이션
         offset = (params.page - 1) * params.page_size
-        courses = query.offset(offset).limit(params.page_size).all()
+        query = query.offset(offset).limit(params.page_size)
         
-        # === 응답 데이터 생성 ===
+        result = await self.db.execute(query)
+        rows = result.all()
         
-        # 강의별 수강 인원 수 계산
-        course_ids = [course.id for course in courses]
-        enrollment_counts = {}
-        
-        if course_ids:
-            enrollment_count_query = (
-                self.db.query(
-                    Enrollment.course_id,
-                    func.count(Enrollment.id).label('count')
-                )
-                .filter(Enrollment.course_id.in_(course_ids))
-                .filter(Enrollment.is_active == True)
-                .group_by(Enrollment.course_id)
-            )
-            
-            for course_id, count in enrollment_count_query:
-                enrollment_counts[course_id] = count
-        
-        # CourseResponse 리스트 생성
+        # 응답 데이터 생성
         items = []
-        for course in courses:
-            # Pydantic의 model_validate 사용 (from_attributes=True 활용)
+        for course, enrollment_count in rows:
             course_data = CourseResponse.model_validate(course)
-            # enrollment_count만 별도로 설정 (DB에 없는 계산 필드)
-            course_data.enrollment_count = enrollment_counts.get(course.id, 0)
+            course_data.enrollment_count = enrollment_count
             items.append(course_data)
         
-        # 전체 페이지 수 계산
         total_pages = math.ceil(total / params.page_size) if total > 0 else 0
         
         return CoursePaginatedResponse(
@@ -142,91 +117,97 @@ class CourseService:
             total_pages=total_pages,
         )
     
-    def get_course_by_id(
+    async def get_course_by_id(
         self,
         course_id: int,
         user_id: Optional[int] = None
     ) -> CourseDetailResponse:
-        """
-        강의 상세 조회
+        """강의 상세 조회 (N+1 문제 해결)"""
         
-        Args:
-            course_id: 강의 ID
-            user_id: 현재 로그인한 사용자 ID (선택사항)
-        
-        Returns:
-            CourseDetailResponse: 강의 상세 정보 (챕터, 강의 영상 포함)
-        
-        Raises:
-            CourseNotFoundError: 강의를 찾을 수 없는 경우
-        """
-        # 강의 조회 (챕터와 강의 영상을 함께 로드)
-        course = (
-            self.db.query(Course)
+        # 강의 조회 (챕터와 강의 영상 eager loading)
+        query = (
+            select(Course)
             .options(
-                joinedload(Course.chapters)
-                .joinedload(Chapter.lectures)
+                selectinload(Course.chapters)
+                .selectinload(Chapter.lectures)
             )
-            .filter(Course.id == course_id)
-            .first()
+            .where(Course.id == course_id)
         )
+        
+        result = await self.db.execute(query)
+        course = result.scalar_one_or_none()
         
         if not course:
             raise CourseNotFoundError(f'ID {course_id}인 강의를 찾을 수 없습니다')
         
-        # 수강 인원 수 계산
-        enrollment_count = (
-            self.db.query(func.count(Enrollment.id))
-            .filter(Enrollment.course_id == course_id)
-            .filter(Enrollment.is_active == True)
-            .scalar()
-        ) or 0
+        # 수강 인원 수
+        enrollment_result = await self.db.execute(
+            select(func.count(Enrollment.id))
+            .where(
+                Enrollment.course_id == course_id,
+                Enrollment.is_active == True
+            )
+        )
+        enrollment_count = enrollment_result.scalar() or 0
         
-        # 사용자의 수강 여부 및 진행률 확인
+        # 사용자의 수강 여부 및 진행률
         is_enrolled = False
         my_progress = None
+        progress_dict = {}
         
         if user_id:
-            enrollment = (
-                self.db.query(Enrollment)
-                .filter(Enrollment.user_id == user_id)
-                .filter(Enrollment.course_id == course_id)
-                .filter(Enrollment.is_active == True)
-                .first()
+            enrollment_result = await self.db.execute(
+                select(Enrollment)
+                .where(
+                    Enrollment.user_id == user_id,
+                    Enrollment.course_id == course_id,
+                    Enrollment.is_active == True
+                )
             )
+            enrollment = enrollment_result.scalar_one_or_none()
             
             if enrollment:
                 is_enrolled = True
                 my_progress = enrollment.progress_rate
+                
+                # 모든 lecture_id 수집
+                lecture_ids = []
+                for chapter in course.chapters:
+                    for lecture in chapter.lectures:
+                        lecture_ids.append(lecture.id)
+                
+                if lecture_ids:
+                    # 한 번의 쿼리로 모든 Progress 가져오기
+                    progress_result = await self.db.execute(
+                        select(Progress)
+                        .where(
+                            Progress.user_id == user_id,
+                            Progress.lecture_id.in_(lecture_ids)
+                        )
+                    )
+                    progresses = progress_result.scalars().all()
+                    
+                    # Dictionary로 변환
+                    progress_dict = {
+                        progress.lecture_id: progress
+                        for progress in progresses
+                    }
         
         # 챕터 및 강의 영상 데이터 변환
         chapters_data = []
-        
-        # 챕터를 순서대로 정렬
         sorted_chapters = sorted(course.chapters, key=lambda c: c.order_number)
         
         for chapter in sorted_chapters:
-            # 강의 영상을 순서대로 정렬
             sorted_lectures = sorted(chapter.lectures, key=lambda l: l.order_number)
-            
-            # 챕터의 총 재생 시간 계산
             chapter_duration = sum(lecture.duration_seconds for lecture in sorted_lectures)
             
-            # 강의 영상 데이터 생성
             lectures_data = []
             for lecture in sorted_lectures:
-                # Pydantic model_validate 사용
                 lecture_data = LectureResponse.model_validate(lecture)
                 
-                # 사용자가 수강 중이면 시청 정보 추가
+                # Progress 정보 추가 (Dictionary에서 조회)
                 if user_id and is_enrolled:
-                    progress = (
-                        self.db.query(Progress)
-                        .filter(Progress.user_id == user_id)
-                        .filter(Progress.lecture_id == lecture.id)
-                        .first()
-                    )
-                    
+                    progress = progress_dict.get(lecture.id)
                     if progress:
                         lecture_data.is_completed = progress.is_completed
                         lecture_data.last_position = progress.last_position
@@ -234,7 +215,6 @@ class CourseService:
                 
                 lectures_data.append(lecture_data)
             
-            # 챕터 데이터 생성
             chapter_data = ChapterWithLectures.model_validate(chapter)
             chapter_data.total_duration = chapter_duration
             chapter_data.lectures = lectures_data
@@ -249,96 +229,34 @@ class CourseService:
         
         return course_detail
     
-    def get_course_metadata(self) -> CourseMetadataResponse:
-        """
-        강의 필터링에 사용할 메타데이터 조회
+    async def get_course_metadata(self) -> CourseMetadataResponse:
+        """강의 메타데이터 조회"""
         
-        카테고리, 강의 유형, 난이도, 가격 타입 정보를 반환합니다.
-        
-        Returns:
-            CourseMetadataResponse: 메타데이터 정보
-        """
-        # 카테고리 메타데이터
         categories = [
-            CategoryMetadata(
-                value=CategoryType.FRONTEND,
-                label="프론트엔드",
-                description="HTML, CSS, JavaScript, React, Vue 등"
-            ),
-            CategoryMetadata(
-                value=CategoryType.BACKEND,
-                label="백엔드",
-                description="Python, Java, Node.js, Spring, Django 등"
-            ),
-            CategoryMetadata(
-                value=CategoryType.DATA_ANALYSIS,
-                label="데이터분석",
-                description="SQL, Python, 데이터 시각화, 통계 등"
-            ),
-            CategoryMetadata(
-                value=CategoryType.AI,
-                label="AI",
-                description="머신러닝, 딥러닝, 자연어처리 등"
-            ),
-            CategoryMetadata(
-                value=CategoryType.DESIGN,
-                label="디자인",
-                description="UI/UX, Figma, 그래픽 디자인 등"
-            ),
-            CategoryMetadata(
-                value=CategoryType.OTHER,
-                label="기타",
-                description="기타 IT 관련 강의"
-            ),
+            CategoryMetadata(value=CategoryType.FRONTEND, label="프론트엔드"),
+            CategoryMetadata(value=CategoryType.BACKEND, label="백엔드"),
+            CategoryMetadata(value=CategoryType.DATA_ANALYSIS, label="데이터분석"),
+            CategoryMetadata(value=CategoryType.AI, label="AI"),
+            CategoryMetadata(value=CategoryType.DESIGN, label="디자인"),
+            CategoryMetadata(value=CategoryType.OTHER, label="기타"),
         ]
         
-        # 강의 유형 메타데이터
-        from models.course import CourseType
         course_types = [
-            CourseTypeMetadata(
-                value=CourseType.VOD,
-                label="VOD 강의"
-            ),
-            CourseTypeMetadata(
-                value=CourseType.BOOST_COMMUNITY,
-                label="부스트 커뮤니티"
-            ),
-            CourseTypeMetadata(
-                value=CourseType.KDC,
-                label="KDC"
-            ),
+            CourseTypeMetadata(value=CourseType.VOD, label="VOD"),
+            CourseTypeMetadata(value=CourseType.BOOST_COMMUNITY, label="부스트캠프"),
+            CourseTypeMetadata(value=CourseType.KDC, label="KDC"),
         ]
         
-        # 난이도 메타데이터
         difficulties = [
-            DifficultyMetadata(
-                value=Difficulty.BEGINNER,
-                label="초급"
-            ),
-            DifficultyMetadata(
-                value=Difficulty.INTERMEDIATE,
-                label="중급"
-            ),
-            DifficultyMetadata(
-                value=Difficulty.ADVANCED,
-                label="고급"
-            ),
+            DifficultyMetadata(value=Difficulty.BEGINNER, label="초급"),
+            DifficultyMetadata(value=Difficulty.INTERMEDIATE, label="중급"),
+            DifficultyMetadata(value=Difficulty.ADVANCED, label="고급"),
         ]
         
-        # 가격 타입 메타데이터
         price_types = [
-            PriceTypeMetadata(
-                value=PriceType.FREE,
-                label="무료"
-            ),
-            PriceTypeMetadata(
-                value=PriceType.PAID,
-                label="유료"
-            ),
-            PriceTypeMetadata(
-                value=PriceType.NATIONAL_SUPPORT,
-                label="국비지원"
-            ),
+            PriceTypeMetadata(value=PriceType.FREE, label="무료"),
+            PriceTypeMetadata(value=PriceType.PAID, label="유료"),
+            PriceTypeMetadata(value=PriceType.NATIONAL_SUPPORT, label="국비지원"),
         ]
         
         return CourseMetadataResponse(
@@ -350,98 +268,77 @@ class CourseService:
     
     # ==================== 챕터 조회 ====================
     
-    def get_chapters_by_course(self, course_id: int) -> List[ChapterResponse]:
-        """
-        특정 강의의 챕터 목록 조회
+    async def get_chapters_by_course(self, course_id: int) -> List[ChapterResponse]:
+        """특정 강의의 챕터 목록 조회"""
         
-        Args:
-            course_id: 강의 ID
+        # 강의 존재 확인
+        course_result = await self.db.execute(
+            select(Course).where(Course.id == course_id)
+        )
+        course = course_result.scalar_one_or_none()
         
-        Returns:
-            List[ChapterResponse]: 챕터 목록
-        
-        Raises:
-            CourseNotFoundError: 강의를 찾을 수 없는 경우
-        """
-        # 강의 존재 여부 확인
-        course = self.db.query(Course).filter(Course.id == course_id).first()
         if not course:
             raise CourseNotFoundError(f'ID {course_id}인 강의를 찾을 수 없습니다')
         
-        # 챕터 목록 조회 (순서대로 정렬)
-        chapters = (
-            self.db.query(Chapter)
-            .filter(Chapter.course_id == course_id)
+        # 챕터 목록 조회
+        chapters_result = await self.db.execute(
+            select(Chapter)
+            .where(Chapter.course_id == course_id)
             .order_by(Chapter.order_number.asc())
-            .all()
         )
+        chapters = chapters_result.scalars().all()
         
         # 챕터별 총 재생 시간 계산
         chapter_responses = []
         for chapter in chapters:
-            # 해당 챕터의 모든 강의 영상의 재생 시간 합계
-            total_duration = (
-                self.db.query(func.sum(Lecture.duration_seconds))
-                .filter(Lecture.chapter_id == chapter.id)
-                .scalar()
-            ) or 0
+            duration_result = await self.db.execute(
+                select(func.sum(Lecture.duration_seconds))
+                .where(Lecture.chapter_id == chapter.id)
+            )
+            total_duration = duration_result.scalar() or 0
             
-            # Pydantic model_validate 사용
             chapter_data = ChapterResponse.model_validate(chapter)
             chapter_data.total_duration = total_duration
             chapter_responses.append(chapter_data)
         
         return chapter_responses
     
-    def get_chapter_by_id(
+    async def get_chapter_by_id(
         self,
         course_id: int,
         chapter_id: int
     ) -> ChapterWithLectures:
-        """
-        특정 챕터의 상세 정보 조회 (강의 영상 포함)
+        """특정 챕터의 상세 정보 조회"""
         
-        Args:
-            course_id: 강의 ID
-            chapter_id: 챕터 ID
-        
-        Returns:
-            ChapterWithLectures: 챕터 상세 정보
-        
-        Raises:
-            CourseNotFoundError: 강의를 찾을 수 없는 경우
-            ChapterNotFoundError: 챕터를 찾을 수 없는 경우
-        """
-        # 강의 존재 여부 확인
-        course = self.db.query(Course).filter(Course.id == course_id).first()
-        if not course:
+        # 강의 존재 확인
+        course_result = await self.db.execute(
+            select(Course).where(Course.id == course_id)
+        )
+        if not course_result.scalar_one_or_none():
             raise CourseNotFoundError(f'ID {course_id}인 강의를 찾을 수 없습니다')
         
-        # 챕터 조회 (강의 영상 포함)
-        chapter = (
-            self.db.query(Chapter)
-            .options(joinedload(Chapter.lectures))
-            .filter(Chapter.id == chapter_id)
-            .filter(Chapter.course_id == course_id)
-            .first()
+        # 챕터 조회
+        chapter_result = await self.db.execute(
+            select(Chapter)
+            .options(selectinload(Chapter.lectures))
+            .where(
+                Chapter.id == chapter_id,
+                Chapter.course_id == course_id
+            )
         )
+        chapter = chapter_result.scalar_one_or_none()
         
         if not chapter:
             raise ChapterNotFoundError(f'ID {chapter_id}인 챕터를 찾을 수 없습니다')
         
-        # 강의 영상을 순서대로 정렬
         sorted_lectures = sorted(chapter.lectures, key=lambda l: l.order_number)
-        
-        # 챕터의 총 재생 시간 계산
         total_duration = sum(lecture.duration_seconds for lecture in sorted_lectures)
         
-        # 강의 영상 데이터 생성
         lectures_data = [
             LectureResponse.model_validate(lecture)
             for lecture in sorted_lectures
         ]
         
-        # 챕터 상세 응답 생성
         chapter_detail = ChapterWithLectures.model_validate(chapter)
         chapter_detail.total_duration = total_duration
         chapter_detail.lectures = lectures_data
@@ -450,119 +347,97 @@ class CourseService:
     
     # ==================== 강의 영상 조회 ====================
     
-    def get_lectures_by_chapter(
+    async def get_lectures_by_chapter(
         self,
         course_id: int,
         chapter_id: int
     ) -> List[LectureResponse]:
-        """
-        특정 챕터의 강의 영상 목록 조회
+        """특정 챕터의 강의 영상 목록 조회"""
         
-        Args:
-            course_id: 강의 ID
-            chapter_id: 챕터 ID
-        
-        Returns:
-            List[LectureResponse]: 강의 영상 목록
-        
-        Raises:
-            CourseNotFoundError: 강의를 찾을 수 없는 경우
-            ChapterNotFoundError: 챕터를 찾을 수 없는 경우
-        """
-        # 강의 존재 여부 확인
-        course = self.db.query(Course).filter(Course.id == course_id).first()
-        if not course:
+        # 강의 존재 확인
+        course_result = await self.db.execute(
+            select(Course).where(Course.id == course_id)
+        )
+        if not course_result.scalar_one_or_none():
             raise CourseNotFoundError(f'ID {course_id}인 강의를 찾을 수 없습니다')
         
-        # 챕터 존재 여부 확인
-        chapter = (
-            self.db.query(Chapter)
-            .filter(Chapter.id == chapter_id)
-            .filter(Chapter.course_id == course_id)
-            .first()
+        # 챕터 존재 확인
+        chapter_result = await self.db.execute(
+            select(Chapter).where(
+                Chapter.id == chapter_id,
+                Chapter.course_id == course_id
+            )
         )
-        if not chapter:
+        if not chapter_result.scalar_one_or_none():
             raise ChapterNotFoundError(f'ID {chapter_id}인 챕터를 찾을 수 없습니다')
         
-        # 강의 영상 목록 조회 (순서대로 정렬)
-        lectures = (
-            self.db.query(Lecture)
-            .filter(Lecture.chapter_id == chapter_id)
+        # 강의 영상 목록 조회
+        lectures_result = await self.db.execute(
+            select(Lecture)
+            .where(Lecture.chapter_id == chapter_id)
             .order_by(Lecture.order_number.asc())
-            .all()
         )
+        lectures = lectures_result.scalars().all()
         
-        # LectureResponse 리스트 생성
         return [
             LectureResponse.model_validate(lecture)
             for lecture in lectures
         ]
     
-    def get_lecture_by_id(
+    async def get_lecture_by_id(
         self,
         course_id: int,
         chapter_id: int,
         lecture_id: int,
         user_id: Optional[int] = None
     ) -> LectureResponse:
-        """
-        특정 강의 영상의 상세 정보 조회
+        """특정 강의 영상의 상세 정보 조회"""
         
-        Args:
-            course_id: 강의 ID
-            chapter_id: 챕터 ID
-            lecture_id: 강의 영상 ID
-            user_id: 현재 로그인한 사용자 ID (선택사항, 시청 정보 조회용)
-        
-        Returns:
-            LectureResponse: 강의 영상 상세 정보
-        
-        Raises:
-            CourseNotFoundError: 강의를 찾을 수 없는 경우
-            ChapterNotFoundError: 챕터를 찾을 수 없는 경우
-            LectureNotFoundError: 강의 영상을 찾을 수 없는 경우
-        """
-        # 강의 존재 여부 확인
-        course = self.db.query(Course).filter(Course.id == course_id).first()
-        if not course:
+        # 강의 존재 확인
+        course_result = await self.db.execute(
+            select(Course).where(Course.id == course_id)
+        )
+        if not course_result.scalar_one_or_none():
             raise CourseNotFoundError(f'ID {course_id}인 강의를 찾을 수 없습니다')
         
-        # 챕터 존재 여부 확인
-        chapter = (
-            self.db.query(Chapter)
-            .filter(Chapter.id == chapter_id)
-            .filter(Chapter.course_id == course_id)
-            .first()
+        # 챕터 존재 확인
+        chapter_result = await self.db.execute(
+            select(Chapter).where(
+                Chapter.id == chapter_id,
+                Chapter.course_id == course_id
+            )
         )
-        if not chapter:
+        if not chapter_result.scalar_one_or_none():
             raise ChapterNotFoundError(f'ID {chapter_id}인 챕터를 찾을 수 없습니다')
         
         # 강의 영상 조회
-        lecture = (
-            self.db.query(Lecture)
-            .filter(Lecture.id == lecture_id)
-            .filter(Lecture.chapter_id == chapter_id)
-            .first()
+        lecture_result = await self.db.execute(
+            select(Lecture).where(
+                Lecture.id == lecture_id,
+                Lecture.chapter_id == chapter_id
+            )
         )
+        lecture = lecture_result.scalar_one_or_none()
         
         if not lecture:
             raise LectureNotFoundError(f'ID {lecture_id}인 강의 영상을 찾을 수 없습니다')
         
-        # 강의 영상 응답 데이터 생성
+        # 사용자의 시청 정보 조회
+        progress = None
+        if user_id:
+            progress_result = await self.db.execute(
+                select(Progress).where(
+                    Progress.user_id == user_id,
+                    Progress.lecture_id == lecture_id
+                )
+            )
+            progress = progress_result.scalar_one_or_none()
+        
         lecture_data = LectureResponse.model_validate(lecture)
         
-        # 사용자의 시청 정보 조회
-        if user_id:
-            progress = (
-                self.db.query(Progress)
-                .filter(Progress.user_id == user_id)
-                .filter(Progress.lecture_id == lecture_id)
-                .first()
-            )
-            
-            if progress:
-                lecture_data.is_completed = progress.is_completed
-                lecture_data.last_position = progress.last_position
-                lecture_data.watched_seconds = progress.watched_seconds
+        if progress:
+            lecture_data.is_completed = progress.is_completed
+            lecture_data.last_position = progress.last_position
+            lecture_data.watched_seconds = progress.watched_seconds
         
         return lecture_data

--- a/services/course_service.py
+++ b/services/course_service.py
@@ -1,0 +1,568 @@
+"""
+Course Service
+강의 관련 비즈니스 로직
+
+"""
+
+from typing import List, Optional, Tuple
+from sqlalchemy.orm import Session, joinedload
+from sqlalchemy import func, or_, and_
+import math
+
+from models.course import Course, Chapter, Lecture, CategoryType, Difficulty, PriceType
+from models.progress import Enrollment
+from models.progress import Progress
+from schemas.course import (
+    CourseListParams,
+    CourseResponse,
+    CourseDetailResponse,
+    CoursePaginatedResponse,
+    ChapterResponse,
+    ChapterWithLectures,
+    LectureResponse,
+    CourseMetadataResponse,
+    CategoryMetadata,
+    CourseTypeMetadata,
+    DifficultyMetadata,
+    PriceTypeMetadata,
+)
+from exceptions.base import (
+    CourseNotFoundError,
+    ChapterNotFoundError,
+    LectureNotFoundError,
+)
+
+
+class CourseService:
+    """강의 관련 비즈니스 로직을 처리하는 서비스 클래스"""
+    
+    def __init__(self, db: Session):
+        """
+        서비스 초기화
+        
+        Args:
+            db: 데이터베이스 세션
+        """
+        self.db = db
+    
+    # ==================== 강의 목록/상세 조회 ====================
+    
+    def get_courses(
+        self,
+        params: CourseListParams,
+        user_id: Optional[int] = None
+    ) -> CoursePaginatedResponse:
+        """
+        강의 목록 조회 (필터링, 페이지네이션, 검색)
+        
+        Args:
+            params: 필터 파라미터 (카테고리, 난이도, 가격 타입, 키워드 등)
+            user_id: 현재 로그인한 사용자 ID (선택사항, 수강 여부 확인용)
+        
+        Returns:
+            CoursePaginatedResponse: 페이지네이션된 강의 목록
+        """
+        # 기본 쿼리 생성
+        query = self.db.query(Course)
+        
+        # === 필터링 ===
+        
+        # 1. 카테고리 필터
+        if params.category_type:
+            query = query.filter(Course.category_type == params.category_type)
+        
+        # 2. 난이도 필터
+        if params.difficulty:
+            query = query.filter(Course.difficulty == params.difficulty)
+        
+        # 3. 가격 타입 필터
+        if params.price_type:
+            query = query.filter(Course.price_type == params.price_type)
+        
+        # 4. 공개 여부 필터 (기본값: 공개된 강의만)
+        if params.is_published is not None:
+            query = query.filter(Course.is_published == params.is_published)
+        
+        # 5. 키워드 검색 (강의명, 강의 설명)
+        if params.keyword:
+            keyword_filter = or_(
+                Course.title.ilike(f'%{params.keyword}%'),
+                Course.description.ilike(f'%{params.keyword}%')
+            )
+            query = query.filter(keyword_filter)
+        
+        # === 정렬 ===
+        # 최신순 정렬 (생성일 기준 내림차순)
+        query = query.order_by(Course.created_at.desc())
+        
+        # === 전체 개수 계산 ===
+        total = query.count()
+        
+        # === 페이지네이션 ===
+        offset = (params.page - 1) * params.page_size
+        courses = query.offset(offset).limit(params.page_size).all()
+        
+        # === 응답 데이터 생성 ===
+        
+        # 강의별 수강 인원 수 계산
+        course_ids = [course.id for course in courses]
+        enrollment_counts = {}
+        
+        if course_ids:
+            enrollment_count_query = (
+                self.db.query(
+                    Enrollment.course_id,
+                    func.count(Enrollment.id).label('count')
+                )
+                .filter(Enrollment.course_id.in_(course_ids))
+                .filter(Enrollment.is_active == True)
+                .group_by(Enrollment.course_id)
+            )
+            
+            for course_id, count in enrollment_count_query:
+                enrollment_counts[course_id] = count
+        
+        # CourseResponse 리스트 생성
+        items = []
+        for course in courses:
+            # Pydantic의 model_validate 사용 (from_attributes=True 활용)
+            course_data = CourseResponse.model_validate(course)
+            # enrollment_count만 별도로 설정 (DB에 없는 계산 필드)
+            course_data.enrollment_count = enrollment_counts.get(course.id, 0)
+            items.append(course_data)
+        
+        # 전체 페이지 수 계산
+        total_pages = math.ceil(total / params.page_size) if total > 0 else 0
+        
+        return CoursePaginatedResponse(
+            items=items,
+            total=total,
+            page=params.page,
+            page_size=params.page_size,
+            total_pages=total_pages,
+        )
+    
+    def get_course_by_id(
+        self,
+        course_id: int,
+        user_id: Optional[int] = None
+    ) -> CourseDetailResponse:
+        """
+        강의 상세 조회
+        
+        Args:
+            course_id: 강의 ID
+            user_id: 현재 로그인한 사용자 ID (선택사항)
+        
+        Returns:
+            CourseDetailResponse: 강의 상세 정보 (챕터, 강의 영상 포함)
+        
+        Raises:
+            CourseNotFoundError: 강의를 찾을 수 없는 경우
+        """
+        # 강의 조회 (챕터와 강의 영상을 함께 로드)
+        course = (
+            self.db.query(Course)
+            .options(
+                joinedload(Course.chapters)
+                .joinedload(Chapter.lectures)
+            )
+            .filter(Course.id == course_id)
+            .first()
+        )
+        
+        if not course:
+            raise CourseNotFoundError(f'ID {course_id}인 강의를 찾을 수 없습니다')
+        
+        # 수강 인원 수 계산
+        enrollment_count = (
+            self.db.query(func.count(Enrollment.id))
+            .filter(Enrollment.course_id == course_id)
+            .filter(Enrollment.is_active == True)
+            .scalar()
+        ) or 0
+        
+        # 사용자의 수강 여부 및 진행률 확인
+        is_enrolled = False
+        my_progress = None
+        
+        if user_id:
+            enrollment = (
+                self.db.query(Enrollment)
+                .filter(Enrollment.user_id == user_id)
+                .filter(Enrollment.course_id == course_id)
+                .filter(Enrollment.is_active == True)
+                .first()
+            )
+            
+            if enrollment:
+                is_enrolled = True
+                my_progress = enrollment.progress_rate
+        
+        # 챕터 및 강의 영상 데이터 변환
+        chapters_data = []
+        
+        # 챕터를 순서대로 정렬
+        sorted_chapters = sorted(course.chapters, key=lambda c: c.order_number)
+        
+        for chapter in sorted_chapters:
+            # 강의 영상을 순서대로 정렬
+            sorted_lectures = sorted(chapter.lectures, key=lambda l: l.order_number)
+            
+            # 챕터의 총 재생 시간 계산
+            chapter_duration = sum(lecture.duration_seconds for lecture in sorted_lectures)
+            
+            # 강의 영상 데이터 생성
+            lectures_data = []
+            for lecture in sorted_lectures:
+                # Pydantic model_validate 사용
+                lecture_data = LectureResponse.model_validate(lecture)
+                
+                # 사용자가 수강 중이면 시청 정보 추가
+                if user_id and is_enrolled:
+                    progress = (
+                        self.db.query(Progress)
+                        .filter(Progress.user_id == user_id)
+                        .filter(Progress.lecture_id == lecture.id)
+                        .first()
+                    )
+                    
+                    if progress:
+                        lecture_data.is_completed = progress.is_completed
+                        lecture_data.last_position = progress.last_position
+                        lecture_data.watched_seconds = progress.watched_seconds
+                
+                lectures_data.append(lecture_data)
+            
+            # 챕터 데이터 생성
+            chapter_data = ChapterWithLectures.model_validate(chapter)
+            chapter_data.total_duration = chapter_duration
+            chapter_data.lectures = lectures_data
+            chapters_data.append(chapter_data)
+        
+        # 강의 상세 응답 생성
+        course_detail = CourseDetailResponse.model_validate(course)
+        course_detail.enrollment_count = enrollment_count
+        course_detail.chapters = chapters_data
+        course_detail.is_enrolled = is_enrolled
+        course_detail.my_progress = my_progress
+        
+        return course_detail
+    
+    def get_course_metadata(self) -> CourseMetadataResponse:
+        """
+        강의 필터링에 사용할 메타데이터 조회
+        
+        카테고리, 강의 유형, 난이도, 가격 타입 정보를 반환합니다.
+        
+        Returns:
+            CourseMetadataResponse: 메타데이터 정보
+        """
+        # 카테고리 메타데이터
+        categories = [
+            CategoryMetadata(
+                value=CategoryType.FRONTEND,
+                label="프론트엔드",
+                description="HTML, CSS, JavaScript, React, Vue 등"
+            ),
+            CategoryMetadata(
+                value=CategoryType.BACKEND,
+                label="백엔드",
+                description="Python, Java, Node.js, Spring, Django 등"
+            ),
+            CategoryMetadata(
+                value=CategoryType.DATA_ANALYSIS,
+                label="데이터분석",
+                description="SQL, Python, 데이터 시각화, 통계 등"
+            ),
+            CategoryMetadata(
+                value=CategoryType.AI,
+                label="AI",
+                description="머신러닝, 딥러닝, 자연어처리 등"
+            ),
+            CategoryMetadata(
+                value=CategoryType.DESIGN,
+                label="디자인",
+                description="UI/UX, Figma, 그래픽 디자인 등"
+            ),
+            CategoryMetadata(
+                value=CategoryType.OTHER,
+                label="기타",
+                description="기타 IT 관련 강의"
+            ),
+        ]
+        
+        # 강의 유형 메타데이터
+        from models.course import CourseType
+        course_types = [
+            CourseTypeMetadata(
+                value=CourseType.VOD,
+                label="VOD 강의"
+            ),
+            CourseTypeMetadata(
+                value=CourseType.BOOST_COMMUNITY,
+                label="부스트 커뮤니티"
+            ),
+            CourseTypeMetadata(
+                value=CourseType.KDC,
+                label="KDC"
+            ),
+        ]
+        
+        # 난이도 메타데이터
+        difficulties = [
+            DifficultyMetadata(
+                value=Difficulty.BEGINNER,
+                label="초급"
+            ),
+            DifficultyMetadata(
+                value=Difficulty.INTERMEDIATE,
+                label="중급"
+            ),
+            DifficultyMetadata(
+                value=Difficulty.ADVANCED,
+                label="고급"
+            ),
+        ]
+        
+        # 가격 타입 메타데이터
+        price_types = [
+            PriceTypeMetadata(
+                value=PriceType.FREE,
+                label="무료"
+            ),
+            PriceTypeMetadata(
+                value=PriceType.PAID,
+                label="유료"
+            ),
+            PriceTypeMetadata(
+                value=PriceType.NATIONAL_SUPPORT,
+                label="국비지원"
+            ),
+        ]
+        
+        return CourseMetadataResponse(
+            categories=categories,
+            course_types=course_types,
+            difficulties=difficulties,
+            price_types=price_types,
+        )
+    
+    # ==================== 챕터 조회 ====================
+    
+    def get_chapters_by_course(self, course_id: int) -> List[ChapterResponse]:
+        """
+        특정 강의의 챕터 목록 조회
+        
+        Args:
+            course_id: 강의 ID
+        
+        Returns:
+            List[ChapterResponse]: 챕터 목록
+        
+        Raises:
+            CourseNotFoundError: 강의를 찾을 수 없는 경우
+        """
+        # 강의 존재 여부 확인
+        course = self.db.query(Course).filter(Course.id == course_id).first()
+        if not course:
+            raise CourseNotFoundError(f'ID {course_id}인 강의를 찾을 수 없습니다')
+        
+        # 챕터 목록 조회 (순서대로 정렬)
+        chapters = (
+            self.db.query(Chapter)
+            .filter(Chapter.course_id == course_id)
+            .order_by(Chapter.order_number.asc())
+            .all()
+        )
+        
+        # 챕터별 총 재생 시간 계산
+        chapter_responses = []
+        for chapter in chapters:
+            # 해당 챕터의 모든 강의 영상의 재생 시간 합계
+            total_duration = (
+                self.db.query(func.sum(Lecture.duration_seconds))
+                .filter(Lecture.chapter_id == chapter.id)
+                .scalar()
+            ) or 0
+            
+            # Pydantic model_validate 사용
+            chapter_data = ChapterResponse.model_validate(chapter)
+            chapter_data.total_duration = total_duration
+            chapter_responses.append(chapter_data)
+        
+        return chapter_responses
+    
+    def get_chapter_by_id(
+        self,
+        course_id: int,
+        chapter_id: int
+    ) -> ChapterWithLectures:
+        """
+        특정 챕터의 상세 정보 조회 (강의 영상 포함)
+        
+        Args:
+            course_id: 강의 ID
+            chapter_id: 챕터 ID
+        
+        Returns:
+            ChapterWithLectures: 챕터 상세 정보
+        
+        Raises:
+            CourseNotFoundError: 강의를 찾을 수 없는 경우
+            ChapterNotFoundError: 챕터를 찾을 수 없는 경우
+        """
+        # 강의 존재 여부 확인
+        course = self.db.query(Course).filter(Course.id == course_id).first()
+        if not course:
+            raise CourseNotFoundError(f'ID {course_id}인 강의를 찾을 수 없습니다')
+        
+        # 챕터 조회 (강의 영상 포함)
+        chapter = (
+            self.db.query(Chapter)
+            .options(joinedload(Chapter.lectures))
+            .filter(Chapter.id == chapter_id)
+            .filter(Chapter.course_id == course_id)
+            .first()
+        )
+        
+        if not chapter:
+            raise ChapterNotFoundError(f'ID {chapter_id}인 챕터를 찾을 수 없습니다')
+        
+        # 강의 영상을 순서대로 정렬
+        sorted_lectures = sorted(chapter.lectures, key=lambda l: l.order_number)
+        
+        # 챕터의 총 재생 시간 계산
+        total_duration = sum(lecture.duration_seconds for lecture in sorted_lectures)
+        
+        # 강의 영상 데이터 생성
+        lectures_data = [
+            LectureResponse.model_validate(lecture)
+            for lecture in sorted_lectures
+        ]
+        
+        # 챕터 상세 응답 생성
+        chapter_detail = ChapterWithLectures.model_validate(chapter)
+        chapter_detail.total_duration = total_duration
+        chapter_detail.lectures = lectures_data
+        
+        return chapter_detail
+    
+    # ==================== 강의 영상 조회 ====================
+    
+    def get_lectures_by_chapter(
+        self,
+        course_id: int,
+        chapter_id: int
+    ) -> List[LectureResponse]:
+        """
+        특정 챕터의 강의 영상 목록 조회
+        
+        Args:
+            course_id: 강의 ID
+            chapter_id: 챕터 ID
+        
+        Returns:
+            List[LectureResponse]: 강의 영상 목록
+        
+        Raises:
+            CourseNotFoundError: 강의를 찾을 수 없는 경우
+            ChapterNotFoundError: 챕터를 찾을 수 없는 경우
+        """
+        # 강의 존재 여부 확인
+        course = self.db.query(Course).filter(Course.id == course_id).first()
+        if not course:
+            raise CourseNotFoundError(f'ID {course_id}인 강의를 찾을 수 없습니다')
+        
+        # 챕터 존재 여부 확인
+        chapter = (
+            self.db.query(Chapter)
+            .filter(Chapter.id == chapter_id)
+            .filter(Chapter.course_id == course_id)
+            .first()
+        )
+        if not chapter:
+            raise ChapterNotFoundError(f'ID {chapter_id}인 챕터를 찾을 수 없습니다')
+        
+        # 강의 영상 목록 조회 (순서대로 정렬)
+        lectures = (
+            self.db.query(Lecture)
+            .filter(Lecture.chapter_id == chapter_id)
+            .order_by(Lecture.order_number.asc())
+            .all()
+        )
+        
+        # LectureResponse 리스트 생성
+        return [
+            LectureResponse.model_validate(lecture)
+            for lecture in lectures
+        ]
+    
+    def get_lecture_by_id(
+        self,
+        course_id: int,
+        chapter_id: int,
+        lecture_id: int,
+        user_id: Optional[int] = None
+    ) -> LectureResponse:
+        """
+        특정 강의 영상의 상세 정보 조회
+        
+        Args:
+            course_id: 강의 ID
+            chapter_id: 챕터 ID
+            lecture_id: 강의 영상 ID
+            user_id: 현재 로그인한 사용자 ID (선택사항, 시청 정보 조회용)
+        
+        Returns:
+            LectureResponse: 강의 영상 상세 정보
+        
+        Raises:
+            CourseNotFoundError: 강의를 찾을 수 없는 경우
+            ChapterNotFoundError: 챕터를 찾을 수 없는 경우
+            LectureNotFoundError: 강의 영상을 찾을 수 없는 경우
+        """
+        # 강의 존재 여부 확인
+        course = self.db.query(Course).filter(Course.id == course_id).first()
+        if not course:
+            raise CourseNotFoundError(f'ID {course_id}인 강의를 찾을 수 없습니다')
+        
+        # 챕터 존재 여부 확인
+        chapter = (
+            self.db.query(Chapter)
+            .filter(Chapter.id == chapter_id)
+            .filter(Chapter.course_id == course_id)
+            .first()
+        )
+        if not chapter:
+            raise ChapterNotFoundError(f'ID {chapter_id}인 챕터를 찾을 수 없습니다')
+        
+        # 강의 영상 조회
+        lecture = (
+            self.db.query(Lecture)
+            .filter(Lecture.id == lecture_id)
+            .filter(Lecture.chapter_id == chapter_id)
+            .first()
+        )
+        
+        if not lecture:
+            raise LectureNotFoundError(f'ID {lecture_id}인 강의 영상을 찾을 수 없습니다')
+        
+        # 강의 영상 응답 데이터 생성
+        lecture_data = LectureResponse.model_validate(lecture)
+        
+        # 사용자의 시청 정보 조회
+        if user_id:
+            progress = (
+                self.db.query(Progress)
+                .filter(Progress.user_id == user_id)
+                .filter(Progress.lecture_id == lecture_id)
+                .first()
+            )
+            
+            if progress:
+                lecture_data.is_completed = progress.is_completed
+                lecture_data.last_position = progress.last_position
+                lecture_data.watched_seconds = progress.watched_seconds
+        
+        return lecture_data


### PR DESCRIPTION
## 개요
- 강의 목록, 상세, 챕터, 영상 조회 등의 기능을 담당하는 라우터를 생성하고 관련 서비스 로직의 기본 구조를 정의했습니다.

## 변경사항
  - 강의 목록 조회 엔드포인트
  - 강의 상세 조회 엔드포인트 
  - 챕터 및 강의 영상 조회 엔드포인트 기본 구조 추가  
- `services/course_service.py` 생성  
  - 강의 관련 비즈니스 로직 함수 정의 (조회 중심)
- `schemas.course` 응답 스키마 및 예외 응답 구조 연동  

## 관련 이슈
**Closes #37 
