### PR TITLE
[FIX] (be-payment): 결제 관련 api 테스트 및 오류  수정

### DIFF
--- a/alembic/versions/7c54060c947b_initial_migration_for_shared_aws_db.py
+++ b/alembic/versions/7c54060c947b_initial_migration_for_shared_aws_db.py
@@ -224,7 +224,7 @@ def upgrade() -> None:
     sa.Column('amount', sa.Integer(), nullable=False, comment='원래 가격'),
     sa.Column('discount_amount', sa.Integer(), nullable=False, comment='할인 금액'),
     sa.Column('final_amount', sa.Integer(), nullable=False, comment='최종 결제 금액'),
-    sa.Column('payment_method', sa.Enum('card', 'transfer', 'easy', name='paymentmethod'), nullable=False, comment='결제 방식'),
+    sa.Column('payment_method', sa.Enum('card', 'transfer', 'toss', name='paymentmethod'), nullable=False, comment='결제 방식'),
     sa.Column('status', sa.Enum('pending', 'completed', 'failed', 'refunded', name='paymentstatus'), nullable=False, comment='결제 상태'),
     sa.Column('transaction_id', sa.String(length=100), nullable=True, comment='PG사 거래 ID'),
     sa.Column('receipt_url', sa.String(length=500), nullable=True, comment='영수증 URL'),

--- a/app/exceptions/base.py
+++ b/app/exceptions/base.py
@@ -240,10 +240,18 @@ class AlreadyPaidError(ConflictError):
         super().__init__(detail=detail)
 
 class PaymentNotFoundError(NotFoundError):
-    
+
     def __init__(
         self,
         detail: str = '결제 내역을 찾을 수 없습니다'
+    ) -> None:
+        super().__init__(detail=detail)
+
+class PaymentConfirmFailedError(BadRequestError):
+
+    def __init__(
+        self,
+        detail: str = '결제 확인에 실패했습니다'
     ) -> None:
         super().__init__(detail=detail)
 

--- a/app/exceptions/responses.py
+++ b/app/exceptions/responses.py
@@ -593,6 +593,35 @@ REFUND_CREATE_RESPONSES = {
     500: COMMON_500,
 }
 
+REFUND_GET_RESPONSES = {
+    401: COMMON_401,
+    403: COMMON_403,
+    404: _make_error_response(
+        'REFUND_NOT_FOUND',
+        '환불 요청을 찾을 수 없습니다',
+        '환불 조회 실패'
+    ),
+    422: COMMON_422,
+    500: COMMON_500,
+}
+
+REFUND_CANCEL_RESPONSES = {
+    400: _make_error_response(
+        'REFUND_CANCEL_NOT_ALLOWED',
+        '처리 중이거나 완료된 환불은 취소할 수 없습니다',
+        '환불 취소 실패'
+    ),
+    401: COMMON_401,
+    403: COMMON_403,
+    404: _make_error_response(
+        'REFUND_NOT_FOUND',
+        '환불 요청을 찾을 수 없습니다',
+        '환불 취소 실패'
+    ),
+    422: COMMON_422,
+    500: COMMON_500,
+}
+
 REFUND_UPDATE_RESPONSES = {
     400: _make_error_response(
         'INVALID_REFUND_STATUS',

--- a/app/models/payment.py
+++ b/app/models/payment.py
@@ -11,7 +11,7 @@ from .base import Base
 class PaymentMethod(str, enum.Enum):
     CARD = "card"
     TRANSFER = "transfer"
-    EASY = "easy"
+    TOSS = "toss"
 
 class PaymentStatus(str, enum.Enum):
     PENDING = "pending"

--- a/app/routers/payment.py
+++ b/app/routers/payment.py
@@ -12,6 +12,8 @@ from app.exceptions.responses import (
     PAYMENT_CREATE_RESPONSES,
     PAYMENT_CONFIRM_RESPONSES,
     REFUND_CREATE_RESPONSES,
+    REFUND_GET_RESPONSES,
+    REFUND_CANCEL_RESPONSES,
     AUTH_RESPONSES,
     AUTH_PERMISSION_RESPONSES,
     MODIFY_RESPONSES,
@@ -290,6 +292,55 @@ async def get_refund(
     }
 )
 async def cancel_refund(
+    refund_id: int = Path(..., gt=0, description="환불 ID"),
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db)
+):
+    """
+    환불 요청 취소
+    - 대기 중인 환불만 취소 가능
+    """
+    service = RefundService(db)
+    result = await service.cancel_refund(refund_id, current_user.id)
+    await db.commit()
+    return MessageResponse(message=result["message"])
+
+@router.get(
+    "/refunds/{refund_id}/details",
+    response_model=SuccessResponse[RefundResponse],
+    summary="환불 상세 조회 (v2)",
+    description="특정 환불 요청의 상세 정보를 조회합니다.",
+    operation_id="user_get_refund_details",
+    responses={
+        200: {"description": "환불 상세 조회 성공"},
+        **REFUND_GET_RESPONSES
+    }
+)
+async def get_refund_details(
+    refund_id: int = Path(..., gt=0, description="환불 ID"),
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db)
+):
+    """
+    환불 상세 조회
+    - 사용자 권한 확인
+    """
+    service = RefundService(db)
+    refund = await service.get_refund(refund_id, current_user.id)
+    return SuccessResponse(data=refund)
+
+@router.delete(
+    "/refunds/{refund_id}/cancel",
+    response_model=MessageResponse,
+    summary="환불 요청 취소 (v2)",
+    description="대기 중인 환불 요청을 취소합니다.",
+    operation_id="user_cancel_refund_v2",
+    responses={
+        200: {"description": "환불 요청 취소 완료"},
+        **REFUND_CANCEL_RESPONSES
+    }
+)
+async def cancel_refund_v2(
     refund_id: int = Path(..., gt=0, description="환불 ID"),
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db)

--- a/app/schemas/payment.py
+++ b/app/schemas/payment.py
@@ -7,7 +7,7 @@ from enum import Enum
 class PaymentMethod(str, Enum):
     CARD = "card"
     TRANSFER = "transfer"
-    EASY = "easy"
+    TOSS = "toss"
 
 class PaymentStatus(str, Enum):
     PENDING = "pending"

--- a/app/services/payment_service.py
+++ b/app/services/payment_service.py
@@ -4,6 +4,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select, func, and_, or_
 from sqlalchemy.orm import selectinload
 import math
+import uuid
 
 from app.models.payment import Payment, Refund, PaymentStatus, PaymentMethod, RefundStatus
 from app.models.course import Course
@@ -22,6 +23,7 @@ from app.schemas.payment import (
 )
 from app.exceptions.base import (
     PaymentNotFoundError,
+    PaymentConfirmFailedError,
     CourseNotFoundError,
     AlreadyPaidError,
     BadRequestError,
@@ -95,7 +97,7 @@ class PaymentService:
             final_amount=final_amount,
             payment_method=data.payment_method,
             status=PaymentStatus.PENDING,
-            transaction_id=None,  # PG사 거래 후 업데이트
+            transaction_id=str(uuid.uuid4()),  # 임시 거래 ID 발급
         )
 
         self.db.add(payment)
@@ -111,7 +113,7 @@ class PaymentService:
             final_amount=payment.final_amount,
             payment_method=payment.payment_method,
             status=payment.status,
-            transaction_id=payment.transaction_id or "",
+            transaction_id=payment.transaction_id,
             receipt_url=payment.receipt_url,
             paid_at=payment.paid_at,
             created_at=payment.created_at,
@@ -295,7 +297,7 @@ class PaymentService:
             raise PaymentNotFoundError()
 
         if payment.status != PaymentStatus.PENDING:
-            raise BadRequestError("결제 상태가 올바르지 않습니다")
+            raise PaymentConfirmFailedError("결제 상태가 올바르지 않습니다")
 
         # 결제 상태 업데이트
         payment.status = PaymentStatus.COMPLETED
@@ -308,8 +310,7 @@ class PaymentService:
             user_id=user_id,
             course_id=payment.course_id,
             is_active=True,
-            start_date=datetime.utcnow(),
-            end_date=datetime.utcnow() + timedelta(days=365*2),
+            expires_at=datetime.utcnow() + timedelta(days=365*2),
         )
         self.db.add(enrollment)
 


### PR DESCRIPTION
## 개요
- 로그인 입력값 검증 기능 추가

## 변경사항
- 문제 1: Enrollment 생성 시 start_date/end_date 에러 해결
파일: bootrun-backend/app/services/payment_service.py 수정 내용:
start_date 파라미터 제거 (Enrollment 모델에 존재하지 않음)
end_date → expires_at로 변경 (올바른 필드명)
enrolled_at은 자동으로 생성됨 (server_default=func.now())
```python
# 수정 전
enrollment = Enrollment(
    user_id=user_id,
    course_id=payment.course_id,
    is_active=True,
    start_date=datetime.utcnow(),           # ❌ 존재하지 않음
    end_date=datetime.utcnow() + timedelta(days=365*2),  # ❌ 잘못된 필드명
)
```
```python
# 수정 후
enrollment = Enrollment(
    user_id=user_id,
    course_id=payment.course_id,
    is_active=True,
    expires_at=datetime.utcnow() + timedelta(days=365*2),  # ✅ 올바른 필드명
)
```

- 문제 2: POST /payments 응답에서 transaction_id 빈값 해결
파일: bootrun-backend/app/services/payment_service.py 수정 내용:
UUID 모듈 추가 (라인 7)
import uuid
결제 생성 시 transaction_id 발급 (라인 99)
```python
# 수정 전
transaction_id=None,  # PG사 거래 후 업데이트

# 수정 후
transaction_id=str(uuid.uuid4()),  # 임시 거래 ID 발급
응답에서 실제 transaction_id 반환 (라인 115)
```
```python
# 수정 전
transaction_id=payment.transaction_id or "",  # 빈 문자열 반환

# 수정 후
transaction_id=payment.transaction_id,  # 실제 값 반환
```

-> POST /payments → 유효한 transaction_id를 포함한 응답 받기
-> POST /payments/{payment_id}/confirm → 500 에러 없이 enrollment 정상 생성

- 추가된 새로운 엔드포인트
1. GET /payments/refunds/{refund_id}/details (환불 상세 조회 v2)
위치: bootrun-backend/app/routers/payment.py
요청 경로: GET /payments/refunds/{refund_id}/details
응답 정의: REFUND_GET_RESPONSES 사용
404 에러 코드: REFUND_NOT_FOUND
기능: 환불 요청의 상세 정보 조회
응답 예시:
```
{
  "error": "REFUND_NOT_FOUND",
  "detail": "환불 요청을 찾을 수 없습니다",
  "path": "/payments/refunds/{refund_id}/details"
}
```

2. DELETE /payments/refunds/{refund_id}/cancel (환불 요청 취소 v2)
위치: bootrun-backend/app/routers/payment.py
요청 경로: DELETE /payments/refunds/{refund_id}/cancel
응답 정의: REFUND_CANCEL_RESPONSES 사용
404 에러 코드: REFUND_NOT_FOUND
400 에러 코드: REFUND_CANCEL_NOT_ALLOWED
기능: 대기 중인 환불 요청 취소
응답 예시:
```
// 404 환불을 찾을 수 없을 때
{
  "error": "REFUND_NOT_FOUND",
  "detail": "환불 요청을 찾을 수 없습니다",
  "path": "/payments/refunds/{refund_id}/cancel"
}
// 400 취소할 수 없는 상태일 때
{
  "error": "REFUND_CANCEL_NOT_ALLOWED",
  "처리 중이거나 완료된 환불은 취소할 수 없습니다",
  "path": "/payments/refunds/{refund_id}/cancel"
}
```
- 완료 사항
-> responses.py에서 REFUND_GET_RESPONSES 추가
-> responses.py에서 REFUND_CANCEL_RESPONSES 추가
-> payment.py에서 import 추가

- 새로운 두 개의 엔드포인트 추가
-> GET /payments/refunds/{refund_id}/details
-> DELETE /payments/refunds/{refund_id}/cancel

- 환불 요청, 환불 상세 조회, 환불 요청 취소 엔드포인트 제외 테스트 완료
- 변경된 결제 방법
-> 이전: CARD, TRANSFER, EASY (신용카드, 계좌이체, 간편결제)
-> 변경 후: CARD, TRANSFER, TOSS (신용카드, 계좌이체, 토스페이)