### PR TITLE
[FEAT] 사용자 관리자 페이지 기능 구현 완료

### DIFF
--- a/app/routers/admin/users.py
+++ b/app/routers/admin/users.py
@@ -14,9 +14,133 @@ from app.exceptions.responses import (
 from app.core.dependencies import get_current_admin, get_db
 from app.models.user import User
 from app.services.admin_user_service import AdminUserService
-from app.exceptions.base import BadRequestError
+from app.exceptions.base import BadRequestError, NotFoundError
 
 router = APIRouter(prefix="/admin/users", tags=["관리자 - 사용자 관리"])
+
+# ================== 1. 고정 경로 (먼저 정의) ==================
+
+@router.get(
+    "/export",
+    summary="사용자 목록 내보내기",
+    description="사용자 목록을 엑셀 파일로 내보냅니다.",
+    responses={
+        200: {"description": "사용자 목록 내보내기 완료"},
+        **ADMIN_RESPONSES
+    }
+)
+async def export_users(
+    params: UserManagementListParams = Depends(),
+    current_admin: User = Depends(get_current_admin),
+    db: AsyncSession = Depends(get_db)
+):
+    pass
+
+# ================== 2. 구체적인 동작 경로 ({user_id}/특정_동작) ==================
+
+@router.patch(
+    "/{user_id}/activate",
+    response_model=MessageResponse,
+    summary="사용자 활성화",
+    description="비활성화된 사용자를 활성화합니다.",
+    responses={
+        200: {"description": "사용자 활성화 완료"},
+        **ADMIN_USER_MANAGEMENT_RESPONSES
+    }
+)
+async def activate_user(
+    user_id: int,
+    current_admin: User = Depends(get_current_admin),
+    db: AsyncSession = Depends(get_db)
+):
+    """사용자 활성화
+
+    - 비활성화된 사용자를 다시 활성화합니다
+    - 활성화 후 사용자는 로그인 가능
+    """
+    service = AdminUserService(db)
+    try:
+        await service.activate_user(user_id)
+    except NotFoundError:
+        raise
+    except ValueError as e:
+        raise BadRequestError(str(e))
+
+    return MessageResponse(
+        success=True,
+        message="사용자가 성공적으로 활성화되었습니다"
+    )
+
+@router.patch(
+    "/{user_id}/deactivate",
+    response_model=MessageResponse,
+    summary="사용자 비활성화",
+    description="사용자를 비활성화합니다.",
+    responses={
+        200: {"description": "사용자 비활성화 완료"},
+        **ADMIN_USER_MANAGEMENT_RESPONSES
+    }
+)
+async def deactivate_user(
+    user_id: int,
+    current_admin: User = Depends(get_current_admin),
+    db: AsyncSession = Depends(get_db)
+):
+    """사용자 비활성화
+
+    - 사용자를 비활성화합니다
+    - 비활성화된 사용자는 로그인 불가
+    """
+    service = AdminUserService(db)
+    try:
+        await service.deactivate_user(user_id)
+    except NotFoundError:
+        raise
+    except ValueError as e:
+        raise BadRequestError(str(e))
+
+    return MessageResponse(
+        success=True,
+        message="사용자가 성공적으로 비활성화되었습니다"
+    )
+
+@router.get(
+    "/{user_id}/learning-report",
+    response_model=SuccessResponse[UserLearningReport],
+    summary="사용자 학습 리포트",
+    description="사용자의 학습 리포트를 조회합니다.",
+    responses={
+        200: {"description": "학습 리포트 조회 성공"},
+        **ADMIN_USER_MANAGEMENT_RESPONSES
+    }
+)
+async def get_user_learning_report(
+    user_id: int,
+    report_period: str,
+    current_admin: User = Depends(get_current_admin),
+    db: AsyncSession = Depends(get_db)
+):
+    """사용자 학습 리포트 조회
+
+    - report_period 형식: YYYY-MM (예: 2025-01)
+    - 월별 총 학습 시간 조회
+    - 강의별 진도 현황 조회
+    - 출석 현황 조회
+    """
+    service = AdminUserService(db)
+    try:
+        report = await service.get_user_learning_report(user_id, report_period)
+    except NotFoundError:
+        raise
+    except ValueError as e:
+        raise BadRequestError(str(e))
+
+    return SuccessResponse(
+        success=True,
+        data=report
+    )
+
+# ================== 3. 일반 경로 (가장 나중에 정의) ==================
 
 @router.get(
     "",
@@ -66,73 +190,14 @@ async def get_user(
     - 수강 중인 강의 목록
     """
     service = AdminUserService(db)
-    user_detail = await service.get_user_detail(user_id)
+    try:
+        user_detail = await service.get_user_detail(user_id)
+    except NotFoundError:
+        raise
 
     return SuccessResponse(
         success=True,
         data=user_detail
-    )
-
-@router.patch(
-    "/{user_id}/activate",
-    response_model=MessageResponse,
-    summary="사용자 활성화",
-    description="비활성화된 사용자를 활성화합니다.",
-    responses={
-        200: {"description": "사용자 활성화 완료"},
-        **ADMIN_USER_MANAGEMENT_RESPONSES
-    }
-)
-async def activate_user(
-    user_id: int,
-    current_admin: User = Depends(get_current_admin),
-    db: AsyncSession = Depends(get_db)
-):
-    """사용자 활성화
-
-    - 비활성화된 사용자를 다시 활성화합니다
-    - 활성화 후 사용자는 로그인 가능
-    """
-    service = AdminUserService(db)
-    try:
-        await service.activate_user(user_id)
-    except ValueError as e:
-        raise BadRequestError(str(e))
-
-    return MessageResponse(
-        success=True,
-        message="사용자가 성공적으로 활성화되었습니다"
-    )
-
-@router.patch(
-    "/{user_id}/deactivate",
-    response_model=MessageResponse,
-    summary="사용자 비활성화",
-    description="사용자를 비활성화합니다.",
-    responses={
-        200: {"description": "사용자 비활성화 완료"},
-        **ADMIN_USER_MANAGEMENT_RESPONSES
-    }
-)
-async def deactivate_user(
-    user_id: int,
-    current_admin: User = Depends(get_current_admin),
-    db: AsyncSession = Depends(get_db)
-):
-    """사용자 비활성화
-
-    - 사용자를 비활성화합니다
-    - 비활성화된 사용자는 로그인 불가
-    """
-    service = AdminUserService(db)
-    try:
-        await service.deactivate_user(user_id)
-    except ValueError as e:
-        raise BadRequestError(str(e))
-
-    return MessageResponse(
-        success=True,
-        message="사용자가 성공적으로 비활성화되었습니다"
     )
 
 @router.delete(
@@ -150,54 +215,20 @@ async def delete_user(
     current_admin: User = Depends(get_current_admin),
     db: AsyncSession = Depends(get_db)
 ):
-    pass
+    """사용자 완전 삭제
 
-@router.get(
-    "/{user_id}/learning-report",
-    response_model=SuccessResponse[UserLearningReport],
-    summary="사용자 학습 리포트",
-    description="사용자의 학습 리포트를 조회합니다.",
-    responses={
-        200: {"description": "학습 리포트 조회 성공"},
-        **ADMIN_USER_MANAGEMENT_RESPONSES
-    }
-)
-async def get_user_learning_report(
-    user_id: int,
-    report_period: str,
-    current_admin: User = Depends(get_current_admin),
-    db: AsyncSession = Depends(get_db)
-):
-    """사용자 학습 리포트 조회
-
-    - report_period 형식: YYYY-MM (예: 2025-01)
-    - 월별 총 학습 시간 조회
-    - 강의별 진도 현황 조회
-    - 출석 현황 조회
+    - 사용자를 완전히 삭제합니다 (카스케이드 삭제)
+    - 연결된 모든 데이터도 함께 삭제됩니다 (주의!)
     """
     service = AdminUserService(db)
     try:
-        report = await service.get_user_learning_report(user_id, report_period)
+        await service.delete_user(user_id)
+    except NotFoundError:
+        raise
     except ValueError as e:
         raise BadRequestError(str(e))
 
-    return SuccessResponse(
+    return MessageResponse(
         success=True,
-        data=report
+        message="사용자가 성공적으로 삭제되었습니다"
     )
-
-@router.get(
-    "/export",
-    summary="사용자 목록 내보내기",
-    description="사용자 목록을 엑셀 파일로 내보냅니다.",
-    responses={
-        200: {"description": "사용자 목록 내보내기 완료"},
-        **ADMIN_RESPONSES
-    }
-)
-async def export_users(
-    params: UserManagementListParams = Depends(),
-    current_admin: User = Depends(get_current_admin),
-    db: AsyncSession = Depends(get_db)
-):
-    pass

--- a/app/routers/admin/users.py
+++ b/app/routers/admin/users.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, status
 from fastapi.responses import StreamingResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -13,6 +13,8 @@ from app.exceptions.responses import (
 )
 from app.core.dependencies import get_current_admin, get_db
 from app.models.user import User
+from app.services.admin_user_service import AdminUserService
+from app.exceptions.base import BadRequestError
 
 router = APIRouter(prefix="/admin/users", tags=["관리자 - 사용자 관리"])
 
@@ -31,7 +33,14 @@ async def get_users(
     current_admin: User = Depends(get_current_admin),
     db: AsyncSession = Depends(get_db)
 ):
-    pass
+    """사용자 목록 조회
+
+    - 역할, 활성화 상태, 키워드, 가입 기간으로 필터링 가능
+    - 페이지네이션 지원
+    - 각 사용자의 수강 등록 수, 결제 횟수, 총 지출액 포함
+    """
+    service = AdminUserService(db)
+    return await service.get_users_list(params)
 
 @router.get(
     "/{user_id}",
@@ -48,7 +57,21 @@ async def get_user(
     current_admin: User = Depends(get_current_admin),
     db: AsyncSession = Depends(get_db)
 ):
-    pass
+    """사용자 상세 정보 조회
+
+    - 사용자 기본 정보 (이메일, 닉네임, 성별, 생년월일 등)
+    - 학습 통계 (총 학습 시간, 수강 등록 수, 완료한 강의 수 등)
+    - 결제 정보 (총 결제 횟수, 총 지출액, 환불액)
+    - 활동 정보 (작성한 질문, 댓글 수)
+    - 수강 중인 강의 목록
+    """
+    service = AdminUserService(db)
+    user_detail = await service.get_user_detail(user_id)
+
+    return SuccessResponse(
+        success=True,
+        data=user_detail
+    )
 
 @router.patch(
     "/{user_id}/activate",
@@ -65,7 +88,21 @@ async def activate_user(
     current_admin: User = Depends(get_current_admin),
     db: AsyncSession = Depends(get_db)
 ):
-    pass
+    """사용자 활성화
+
+    - 비활성화된 사용자를 다시 활성화합니다
+    - 활성화 후 사용자는 로그인 가능
+    """
+    service = AdminUserService(db)
+    try:
+        await service.activate_user(user_id)
+    except ValueError as e:
+        raise BadRequestError(str(e))
+
+    return MessageResponse(
+        success=True,
+        message="사용자가 성공적으로 활성화되었습니다"
+    )
 
 @router.patch(
     "/{user_id}/deactivate",
@@ -82,7 +119,21 @@ async def deactivate_user(
     current_admin: User = Depends(get_current_admin),
     db: AsyncSession = Depends(get_db)
 ):
-    pass
+    """사용자 비활성화
+
+    - 사용자를 비활성화합니다
+    - 비활성화된 사용자는 로그인 불가
+    """
+    service = AdminUserService(db)
+    try:
+        await service.deactivate_user(user_id)
+    except ValueError as e:
+        raise BadRequestError(str(e))
+
+    return MessageResponse(
+        success=True,
+        message="사용자가 성공적으로 비활성화되었습니다"
+    )
 
 @router.delete(
     "/{user_id}",
@@ -117,7 +168,23 @@ async def get_user_learning_report(
     current_admin: User = Depends(get_current_admin),
     db: AsyncSession = Depends(get_db)
 ):
-    pass
+    """사용자 학습 리포트 조회
+
+    - report_period 형식: YYYY-MM (예: 2025-01)
+    - 월별 총 학습 시간 조회
+    - 강의별 진도 현황 조회
+    - 출석 현황 조회
+    """
+    service = AdminUserService(db)
+    try:
+        report = await service.get_user_learning_report(user_id, report_period)
+    except ValueError as e:
+        raise BadRequestError(str(e))
+
+    return SuccessResponse(
+        success=True,
+        data=report
+    )
 
 @router.get(
     "/export",

--- a/app/services/admin_user_service.py
+++ b/app/services/admin_user_service.py
@@ -154,7 +154,7 @@ class AdminUserService:
 
     async def activate_user(self, user_id: int) -> None:
         """사용자 활성화"""
-        user = await self._get_user(user_id)
+        user = await self._get_user(user_id)  # NotFoundError 발생 가능
 
         if user.is_active:
             raise ValueError("이미 활성화된 사용자입니다")
@@ -172,6 +172,13 @@ class AdminUserService:
 
         user.is_active = False
         user.updated_at = datetime.utcnow()
+        await self.db.commit()
+
+    async def delete_user(self, user_id: int) -> None:
+        """사용자 완전 삭제"""
+        user = await self._get_user(user_id)
+
+        await self.db.delete(user)
         await self.db.commit()
 
     async def get_user_learning_report(

--- a/app/services/admin_user_service.py
+++ b/app/services/admin_user_service.py
@@ -1,0 +1,543 @@
+from typing import Optional, List
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select, func, and_, or_, desc
+from datetime import datetime
+
+from app.models.user import User
+from app.models.progress import Enrollment, Progress
+from app.models.payment import Payment
+from app.models.course import Course
+from app.schemas.admin import (
+    UserManagementListParams, UserManagementResponse,
+    UserDetailForAdmin, UserLearningReport,
+    UserProgressDetail, UserAttendanceRecord,
+    UserManagementPaginatedResponse
+)
+from app.exceptions.base import NotFoundError
+from app.utils.helpers import calculate_total_pages, calculate_offset
+
+
+class AdminUserService:
+    def __init__(self, db: AsyncSession):
+        self.db = db
+
+    async def get_users_list(
+        self,
+        params: UserManagementListParams
+    ) -> UserManagementPaginatedResponse:
+        """사용자 목록 조회 (페이지네이션 포함)"""
+        conditions = []
+
+        if params.role:
+            conditions.append(User.role == params.role)
+
+        if params.is_active is not None:
+            conditions.append(User.is_active == params.is_active)
+
+        if params.keyword:
+            keyword_pattern = f"%{params.keyword}%"
+            conditions.append(
+                or_(
+                    User.nickname.ilike(keyword_pattern),
+                    User.email.ilike(keyword_pattern)
+                )
+            )
+
+        if params.start_date:
+            conditions.append(User.created_at >= params.start_date)
+
+        if params.end_date:
+            conditions.append(User.created_at <= params.end_date)
+
+        # 기본 쿼리 구성
+        base_query = select(User)
+        if conditions:
+            base_query = base_query.where(and_(*conditions))
+
+        # 전체 개수 조회
+        count_query = select(func.count(User.id))
+        if conditions:
+            count_query = count_query.where(and_(*conditions))
+
+        count_result = await self.db.execute(count_query)
+        total = count_result.scalar() or 0
+
+        # 페이징 처리
+        offset = calculate_offset(params.page, params.page_size)
+        query = (
+            base_query
+            .order_by(desc(User.created_at))
+            .limit(params.page_size)
+            .offset(offset)
+        )
+
+        result = await self.db.execute(query)
+        users = result.scalars().all()
+
+        # 각 사용자의 통계 정보 조회
+        items = []
+        for user in users:
+            total_enrollments = await self._count_enrollments(user.id)
+            total_payments = await self._count_payments(user.id)
+            total_spent = await self._calculate_total_spent(user.id)
+
+            item = UserManagementResponse(
+                id=user.id,
+                email=user.email,
+                nickname=user.nickname,
+                role=user.role,
+                is_active=user.is_active,
+                total_enrollments=total_enrollments,
+                total_payments=total_payments,
+                total_spent=total_spent,
+                created_at=user.created_at,
+                last_login=user.last_login
+            )
+            items.append(item)
+
+        total_pages = calculate_total_pages(total, params.page_size)
+
+        return UserManagementPaginatedResponse(
+            total=total,
+            page=params.page,
+            page_size=params.page_size,
+            total_pages=total_pages,
+            items=items
+        )
+
+    async def get_user_detail(self, user_id: int) -> UserDetailForAdmin:
+        """사용자 상세 정보 조회"""
+        user = await self._get_user(user_id)
+
+        # 학습 통계
+        total_study_time = await self._calculate_total_study_time(user_id)
+        total_enrollments = await self._count_enrollments(user_id)
+        active_enrollments = await self._count_active_enrollments(user_id)
+        completed_courses = await self._count_completed_courses(user_id)
+        avg_progress_rate = await self._calculate_avg_progress_rate(user_id)
+
+        # 결제 정보
+        total_payments = await self._count_payments(user_id)
+        total_spent = await self._calculate_total_spent(user_id)
+        total_refunds = await self._calculate_total_refunds(user_id)
+
+        # 활동 정보
+        total_questions = await self._count_questions(user_id)
+        total_comments = await self._count_comments(user_id)
+
+        # 수강 정보
+        enrollments = await self._get_enrollment_details(user_id)
+
+        return UserDetailForAdmin(
+            id=user.id,
+            email=user.email,
+            nickname=user.nickname,
+            gender=user.gender or "미지정",
+            birth_date=user.birth_date,
+            role=user.role,
+            is_active=user.is_active,
+            provider=user.social_provider,
+            created_at=user.created_at,
+            last_login=user.last_login,
+            total_study_time=total_study_time,
+            total_enrollments=total_enrollments,
+            active_enrollments=active_enrollments,
+            completed_courses=completed_courses,
+            avg_progress_rate=avg_progress_rate,
+            total_payments=total_payments,
+            total_spent=total_spent,
+            total_refunds=total_refunds,
+            total_questions=total_questions,
+            total_comments=total_comments,
+            enrollments=enrollments
+        )
+
+    async def activate_user(self, user_id: int) -> None:
+        """사용자 활성화"""
+        user = await self._get_user(user_id)
+
+        if user.is_active:
+            raise ValueError("이미 활성화된 사용자입니다")
+
+        user.is_active = True
+        user.updated_at = datetime.utcnow()
+        await self.db.commit()
+
+    async def deactivate_user(self, user_id: int) -> None:
+        """사용자 비활성화"""
+        user = await self._get_user(user_id)
+
+        if not user.is_active:
+            raise ValueError("이미 비활성화된 사용자입니다")
+
+        user.is_active = False
+        user.updated_at = datetime.utcnow()
+        await self.db.commit()
+
+    async def get_user_learning_report(
+        self,
+        user_id: int,
+        report_period: str
+    ) -> UserLearningReport:
+        """사용자 학습 리포트 조회"""
+        user = await self._get_user(user_id)
+
+        # 기간 파싱 (예: "2025-01")
+        try:
+            period_parts = report_period.split("-")
+            year = int(period_parts[0])
+            month = int(period_parts[1])
+        except (IndexError, ValueError):
+            raise ValueError("리포트 기간 형식이 올바르지 않습니다 (예: 2025-01)")
+
+        # 월별 시작/종료일 계산
+        if month == 12:
+            month_end_year = year + 1
+            month_end = 1
+        else:
+            month_end_year = year
+            month_end = month + 1
+
+        period_start = datetime(year, month, 1)
+        period_end = datetime(month_end_year, month_end, 1)
+
+        # 총 학습 시간 계산
+        total_study_time = await self._calculate_total_study_time(
+            user_id,
+            period_start,
+            period_end
+        )
+
+        # 수강 정보
+        enrollments_query = select(Enrollment).where(
+            and_(
+                Enrollment.user_id == user_id,
+                Enrollment.is_active == True
+            )
+        )
+        enrollments_result = await self.db.execute(enrollments_query)
+        enrollments_list = enrollments_result.scalars().all()
+
+        # 진도 상세 정보
+        courses_detail = []
+        for enrollment in enrollments_list:
+            course_query = select(Course).where(Course.id == enrollment.course_id)
+            course_result = await self.db.execute(course_query)
+            course = course_result.scalar_one()
+
+            progress_detail = UserProgressDetail(
+                course_id=course.id,
+                course_title=course.title,
+                enrolled_at=enrollment.enrolled_at,
+                expires_at=enrollment.expires_at,
+                progress_rate=enrollment.progress_rate,
+                total_lectures=await self._count_course_lectures(course.id),
+                completed_lectures=await self._count_completed_lectures(
+                    user_id,
+                    course.id
+                ),
+                total_study_time=await self._calculate_course_study_time(
+                    user_id,
+                    course.id,
+                    period_start,
+                    period_end
+                ),
+                last_watched_at=await self._get_last_watched_time(user_id, course.id)
+            )
+            courses_detail.append(progress_detail)
+
+        # 출석 기록
+        from datetime import timedelta
+        attendance_records = []
+        current_date = period_start
+        while current_date < period_end:
+            daily_study = await self._get_daily_study_time(user_id, current_date)
+            is_present = daily_study > 0
+
+            record = UserAttendanceRecord(
+                date=current_date.date(),
+                is_present=is_present,
+                study_time=daily_study,
+                lectures_watched=await self._count_daily_lectures_watched(user_id, current_date)
+            )
+            attendance_records.append(record)
+
+            # 다음 날로 이동
+            current_date = current_date + timedelta(days=1)
+
+        # 평균 진도율 계산
+        avg_progress = sum(c.progress_rate for c in courses_detail) / len(courses_detail) if courses_detail else 0
+
+        # 출석률 계산
+        attendance_rate = (
+            sum(1 for a in attendance_records if a.is_present) / len(attendance_records) * 100
+            if attendance_records else 0
+        )
+
+        return UserLearningReport(
+            user_id=user.id,
+            user_nickname=user.nickname,
+            report_period=report_period,
+            total_study_time=total_study_time,
+            attendance_rate=attendance_rate,
+            avg_progress_rate=avg_progress,
+            courses=courses_detail,
+            attendance=attendance_records
+        )
+
+    # ==================== Helper Methods ====================
+
+    async def _get_user(self, user_id: int) -> User:
+        """사용자 조회"""
+        query = select(User).where(User.id == user_id)
+        result = await self.db.execute(query)
+        user = result.scalar_one_or_none()
+
+        if not user:
+            raise NotFoundError("사용자를 찾을 수 없습니다")
+
+        return user
+
+    async def _count_enrollments(self, user_id: int) -> int:
+        """총 수강 등록 수"""
+        query = select(func.count(Enrollment.id)).where(
+            Enrollment.user_id == user_id
+        )
+        result = await self.db.execute(query)
+        return result.scalar() or 0
+
+    async def _count_active_enrollments(self, user_id: int) -> int:
+        """활성 수강 등록 수"""
+        query = select(func.count(Enrollment.id)).where(
+            and_(
+                Enrollment.user_id == user_id,
+                Enrollment.is_active == True
+            )
+        )
+        result = await self.db.execute(query)
+        return result.scalar() or 0
+
+    async def _count_completed_courses(self, user_id: int) -> int:
+        """완료한 강의 수"""
+        query = select(func.count(Enrollment.id)).where(
+            and_(
+                Enrollment.user_id == user_id,
+                Enrollment.progress_rate >= 100
+            )
+        )
+        result = await self.db.execute(query)
+        return result.scalar() or 0
+
+    async def _count_payments(self, user_id: int) -> int:
+        """총 결제 횟수"""
+        query = select(func.count(Payment.id)).where(
+            Payment.user_id == user_id
+        )
+        result = await self.db.execute(query)
+        return result.scalar() or 0
+
+    async def _calculate_total_spent(self, user_id: int) -> int:
+        """총 지출액"""
+        query = select(func.sum(Payment.final_amount)).where(
+            Payment.user_id == user_id
+        )
+        result = await self.db.execute(query)
+        return result.scalar() or 0
+
+    async def _calculate_total_refunds(self, user_id: int) -> int:
+        """총 환불액"""
+        from app.models.payment import Refund
+        query = select(func.sum(Refund.amount)).where(
+            Refund.user_id == user_id
+        )
+        result = await self.db.execute(query)
+        return result.scalar() or 0
+
+    async def _count_questions(self, user_id: int) -> int:
+        """작성한 질문 수"""
+        from app.models.question import CourseQuestion
+        query = select(func.count(CourseQuestion.id)).where(
+            CourseQuestion.user_id == user_id
+        )
+        result = await self.db.execute(query)
+        return result.scalar() or 0
+
+    async def _count_comments(self, user_id: int) -> int:
+        """작성한 답변/댓글 수"""
+        from app.models.question import Comment
+        query = select(func.count(Comment.id)).where(
+            Comment.user_id == user_id
+        )
+        result = await self.db.execute(query)
+        return result.scalar() or 0
+
+    async def _calculate_total_study_time(
+        self,
+        user_id: int,
+        start_date: Optional[datetime] = None,
+        end_date: Optional[datetime] = None
+    ) -> int:
+        """총 학습 시간 (분)"""
+        query = select(func.sum(Progress.watched_seconds)).where(
+            Progress.user_id == user_id
+        )
+
+        if start_date:
+            query = query.where(Progress.last_watched_at >= start_date)
+        if end_date:
+            query = query.where(Progress.last_watched_at < end_date)
+
+        result = await self.db.execute(query)
+        total_seconds = result.scalar() or 0
+        return int(total_seconds / 60)
+
+    async def _calculate_avg_progress_rate(self, user_id: int) -> float:
+        """평균 진도율"""
+        query = select(func.avg(Enrollment.progress_rate)).where(
+            and_(
+                Enrollment.user_id == user_id,
+                Enrollment.is_active == True
+            )
+        )
+        result = await self.db.execute(query)
+        avg = result.scalar()
+        return float(avg) if avg else 0.0
+
+    async def _get_enrollment_details(self, user_id: int) -> List[dict]:
+        """수강 정보 목록"""
+        query = select(Enrollment, Course).join(Course).where(
+            Enrollment.user_id == user_id
+        )
+        result = await self.db.execute(query)
+        enrollments = result.all()
+
+        details = []
+        for enrollment, course in enrollments:
+            details.append({
+                "course_id": course.id,
+                "course_title": course.title,
+                "enrolled_at": enrollment.enrolled_at,
+                "expires_at": enrollment.expires_at,
+                "progress_rate": enrollment.progress_rate,
+                "is_active": enrollment.is_active
+            })
+
+        return details
+
+    async def _count_course_lectures(self, course_id: int) -> int:
+        """강의의 전체 강의 수"""
+        from app.models.course import Chapter, Lecture
+        query = select(func.count(Lecture.id)).join(
+            Chapter, Chapter.id == Lecture.chapter_id
+        ).where(Chapter.course_id == course_id)
+        result = await self.db.execute(query)
+        return result.scalar() or 0
+
+    async def _count_completed_lectures(
+        self,
+        user_id: int,
+        course_id: int
+    ) -> int:
+        """강의별 완료한 강의 수"""
+        from app.models.course import Chapter, Lecture
+        query = select(func.count(Progress.id)).join(
+            Lecture, Lecture.id == Progress.lecture_id
+        ).join(
+            Chapter, Chapter.id == Lecture.chapter_id
+        ).where(
+            and_(
+                Progress.user_id == user_id,
+                Chapter.course_id == course_id,
+                Progress.is_completed == True
+            )
+        )
+        result = await self.db.execute(query)
+        return result.scalar() or 0
+
+    async def _calculate_course_study_time(
+        self,
+        user_id: int,
+        course_id: int,
+        start_date: Optional[datetime] = None,
+        end_date: Optional[datetime] = None
+    ) -> int:
+        """강의별 학습 시간 (분)"""
+        from app.models.course import Chapter, Lecture
+        query = select(func.sum(Progress.watched_seconds)).join(
+            Lecture, Lecture.id == Progress.lecture_id
+        ).join(
+            Chapter, Chapter.id == Lecture.chapter_id
+        ).where(
+            and_(
+                Progress.user_id == user_id,
+                Chapter.course_id == course_id
+            )
+        )
+
+        if start_date:
+            query = query.where(Progress.last_watched_at >= start_date)
+        if end_date:
+            query = query.where(Progress.last_watched_at < end_date)
+
+        result = await self.db.execute(query)
+        total_seconds = result.scalar() or 0
+        return int(total_seconds / 60)
+
+    async def _get_last_watched_time(
+        self,
+        user_id: int,
+        course_id: int
+    ) -> Optional[datetime]:
+        """강의별 마지막 시청 시간"""
+        from app.models.course import Chapter, Lecture
+        query = select(func.max(Progress.last_watched_at)).join(
+            Lecture, Lecture.id == Progress.lecture_id
+        ).join(
+            Chapter, Chapter.id == Lecture.chapter_id
+        ).where(
+            and_(
+                Progress.user_id == user_id,
+                Chapter.course_id == course_id
+            )
+        )
+        result = await self.db.execute(query)
+        return result.scalar()
+
+    async def _get_daily_study_time(
+        self,
+        user_id: int,
+        date: datetime
+    ) -> int:
+        """일별 학습 시간 (분)"""
+        from datetime import timedelta
+        next_date = date + timedelta(days=1)
+
+        query = select(func.sum(Progress.watched_seconds)).where(
+            and_(
+                Progress.user_id == user_id,
+                Progress.last_watched_at >= date,
+                Progress.last_watched_at < next_date
+            )
+        )
+        result = await self.db.execute(query)
+        total_seconds = result.scalar() or 0
+        return int(total_seconds / 60)
+
+    async def _count_daily_lectures_watched(
+        self,
+        user_id: int,
+        date: datetime
+    ) -> int:
+        """일별 시청한 강의 수"""
+        from datetime import timedelta
+        next_date = date + timedelta(days=1)
+
+        query = select(func.count(Progress.id)).where(
+            and_(
+                Progress.user_id == user_id,
+                Progress.last_watched_at >= date,
+                Progress.last_watched_at < next_date
+            )
+        )
+        result = await self.db.execute(query)
+        return result.scalar() or 0


### PR DESCRIPTION
## 개요
### 1. 구현된 엔드포인트
-1) GET /admin/users (필수)
>사용자 목록 조회
필터링: 역할(role), 활성화 상태(is_active), 키워드(nickname/email), 가입 기간(start_date/end_date)
페이지네이션 지원 (page, page_size)
반환 정보: 각 사용자의 수강 등록 수, 결제 횟수, 총 지출액

-2) GET /admin/users/{user_id} (필수)
>사용자 상세 조회
사용자 기본 정보 (이메일, 닉네임, 성별, 생년월일, 역할, 활성화 상태 등)
학습 통계 (총 학습 시간, 수강 등록 수, 완료한 강의 수, 평균 진도율)
결제 정보 (총 결제 횟수, 총 지출액, 환불액)
활동 정보 (작성한 질문 수, 댓글 수)
수강 중인 강의 목록

-3) PATCH /admin/users/{user_id}/activate (추가)
>사용자 활성화
비활성화된 사용자를 다시 활성화
활성화 후 사용자는 로그인 가능

-4) PATCH /admin/users/{user_id}/deactivate (추가)
>사용자 비활성화
사용자를 비활성화
비활성화된 사용자는 로그인 불가

-5) GET /admin/users/{user_id}/learning-report (선택)
>사용자 학습 리포트
기간 형식: YYYY-MM (예: 2025-01)
월별 총 학습 시간
강의별 진도 현황 (강의제목, 수강일시, 만료일시, 진도율, 강의수, 완료수, 학습시간)
출석 현황 (일별 출석 여부, 학습 시간, 시청한 강의 수)
평균 진도율 및 출석률 계산

### 2. 구현된 파일
-1) [app/services/admin_user_service.py] (신규 생성)
>주요 메서드:
get_users_list(): 사용자 목록 조회 (페이지네이션, 필터링)
get_user_detail(): 사용자 상세 정보 조회
activate_user(): 사용자 활성화
deactivate_user(): 사용자 비활성화
get_user_learning_report(): 사용자 학습 리포트 조회

>Helper 메서드들:
_count_enrollments(): 총 수강 등록 수
_count_active_enrollments(): 활성 수강 등록 수
_count_completed_courses(): 완료한 강의 수
_calculate_total_study_time(): 총 학습 시간
_calculate_avg_progress_rate(): 평균 진도율

그 외 통계 계산 메서드들

-2) [app/routers/admin/users.py] (수정)
>get_users(): GET /admin/users 엔드포인트
get_user(): GET /admin/users/{user_id} 엔드포인트
activate_user(): PATCH /admin/users/{user_id}/activate 엔드포인트
deactivate_user(): PATCH /admin/users/{user_id}/deactivate 엔드포인트
get_user_learning_report(): GET /admin/users/{user_id}/learning-report 엔드포인트

### 3. 주요 기능 특징
>완전한 사용자 관리: 목록 조회, 상세 조회, 활성화/비활성화
상세한 학습 통계: 학습 시간, 진도율, 강의별 진행 상황
유연한 필터링: 역할, 활성화 상태, 키워드, 날짜 범위로 필터링
페이지네이션: 대규모 사용자 목록 처리
월별 학습 리포트: 기간별 학습 현황 및 출석 기록
에러 처리: 사용자 없음, 유효하지 않은 상태 변경 등 적절한 에러 처리

### 4. 기존 스키마와의 통합
>UserManagementListParams: 필터링 및 페이지네이션 파라미터
UserManagementResponse: 사용자 목록 항목
UserDetailForAdmin: 사용자 상세 정보
UserLearningReport: 학습 리포트
UserProgressDetail: 강의별 진도 상세정보
UserAttendanceRecord: 출석 기록


## 변경사항
### 1) DELETE /admin/users/{user_id} - 500 에러 해결
문제: 엔드포인트가 구현되지 않아 500 에러 발생 해결책:
- AdminUserService에 delete_user() 메서드 추가
- 라우터의 delete_user() 함수 구현
- 사용자를 데이터베이스에서 완전히 삭제 (카스케이드 삭제)
응답:
```
{
  "success": true,
  "message": "사용자가 성공적으로 삭제되었습니다"
}
```
### 2) PATCH /admin/users/{user_id}/activate - 404 에러 형식 수정
문제: 404 에러가 Swagger에 정의된 형식과 다르게 반환됨
기대: {"error": "USER_NOT_FOUND", "detail": "사용자를 찾을 수 없습니다"}
실제: {"detail": "Not Found"}
해결책:
모든 사용자 관련 엔드포인트에서 NotFoundError 예외를 명시적으로 처리
NotFoundError는 자동으로 다음 형식으로 변환됨:
```
{
  "error": "NOT_FOUND",
  "detail": "사용자를 찾을 수 없습니다"
}
```

### 3)PATCH /admin/users/{user_id}/activate 엔드포인트에서 404 에러 발생 원인: FastAPI 경로 라우팅 순서 문제

구체적인 경로 /{user_id}/activate 보다 일반 경로 /{user_id}가 먼저 정의됨
/activate를 {user_id} 파라미터로 인식하여 잘못된 경로 매칭 발생
- 해결방법
경로 특수성 순서 재정렬 (Specificity Order):
1. 고정 경로 (먼저 정의)
   └─ GET /export

2. 구체적인 동작 경로 (다음 정의)
   ├─ PATCH /{user_id}/activate
   ├─ PATCH /{user_id}/deactivate
   └─ GET /{user_id}/learning-report

3. 일반 경로 (마지막 정의)
   ├─ GET /
   ├─ GET /{user_id}
   └─ DELETE /{user_id}

## 그 외
- API 로컬 테스트 완료✅

## 관련 이슈
**Closes #62 