### PR TITLE
[FEAT] 동영상 학습 기록 저장 및 진행률 기능 구현

### DIFF
--- a/app/routers/enrollment.py
+++ b/app/routers/enrollment.py
@@ -21,16 +21,14 @@ from app.services.enrollment_service import EnrollmentService
 
 router = APIRouter(prefix="/enrollments", tags=["수강 등록 및 학습 진행"])
 
+
 @router.get(
     "/my",
     response_model=SuccessResponse[MyCoursePaginatedResponse],
     summary="내 수강 목록 조회",
     description="현재 사용자가 수강 중인 강의 목록을 조회합니다. 상태, 학습 진행도, 유형별로 필터링할 수 있습니다.",
-    responses={
-        200: {"description": "수강 목록 조회 성공"},
-        **AUTH_RESPONSES
-    }
-)
+    responses={**AUTH_RESPONSES})
+
 async def get_my_enrollments(
     params: MyCourseListParams = Depends(),
     current_user: User = Depends(get_current_user),
@@ -40,16 +38,14 @@ async def get_my_enrollments(
     result = await service.get_my_courses(current_user.id, params)
     return SuccessResponse(data=result)
 
+
 @router.get(
     "/dashboard",
     response_model=SuccessResponse[StudentDashboard],
     summary="학습자 대시보드",
     description="학습자의 전체 학습 현황을 요약하여 보여줍니다.",
-    responses={
-        200: {"description": "대시보드 조회 성공"},
-        **AUTH_RESPONSES
-    }
-)
+    responses={**AUTH_RESPONSES})
+
 async def get_student_dashboard(
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db)
@@ -58,17 +54,14 @@ async def get_student_dashboard(
     result = await service.get_student_dashboard(current_user.id)
     return SuccessResponse(data=result)
 
+
 @router.get(
     "/{course_id}",
     response_model=SuccessResponse[MyCourseDetail],
     summary="내 강의실 조회",
     description="수강 중인 강의의 상세 정보를 조회합니다. 챕터별 강의 영상 목록과 각 영상의 시청 진행 상태를 확인할 수 있습니다.",
-    responses={
-        200: {"description": "내 강의실 조회 성공"},
-        **AUTH_RESPONSES,
-        **READ_RESPONSES
-    }
-)
+    responses={**AUTH_RESPONSES,**READ_RESPONSES})
+
 async def get_enrollment(
     course_id: int,
     current_user: User = Depends(get_current_user),
@@ -78,17 +71,15 @@ async def get_enrollment(
     result = await service.get_my_course_detail(current_user.id, course_id)
     return SuccessResponse(data=result)
 
+
 @router.post(
     "/progress",
     response_model=SuccessResponse[ProgressResponse],
     status_code=status.HTTP_201_CREATED,
     summary="학습 진행 생성",
     description="강의 영상의 학습 진행을 생성하거나 업데이트합니다. 이미 진행 기록이 있으면 자동으로 업데이트됩니다.",
-    responses={
-        201: {"description": "학습 진행 생성 성공"},
-        **PROGRESS_UPDATE_RESPONSES
-    }
-)
+    responses={**PROGRESS_UPDATE_RESPONSES})
+
 async def create_progress(
     data: ProgressCreate,
     current_user: User = Depends(get_current_user),
@@ -98,16 +89,14 @@ async def create_progress(
     result = await service.create_progress(current_user.id, data)
     return SuccessResponse(data=result)
 
+
 @router.patch(
     "/progress/lectures/{lecture_id}",
     response_model=SuccessResponse[ProgressResponse],
     summary="학습 진행 업데이트",
     description="강의 영상의 학습 진행 상태를 업데이트합니다.",
-    responses={
-        200: {"description": "학습 진행 업데이트 성공"},
-        **PROGRESS_UPDATE_RESPONSES
-    }
-)
+    responses={**PROGRESS_UPDATE_RESPONSES})
+
 async def update_progress(
     lecture_id: int,
     data: ProgressUpdate,
@@ -118,16 +107,14 @@ async def update_progress(
     result = await service.update_progress(current_user.id, lecture_id, data)
     return SuccessResponse(data=result)
 
+
 @router.get(
     "/progress/course/{course_id}",
     response_model=SuccessResponse[CourseProgressDetail],
     summary="강의별 학습 진행 조회",
     description="특정 강의의 전체 학습 진행 상황을 조회합니다.",
-    responses={
-        200: {"description": "학습 진행 조회 성공"},
-        **ENROLLMENT_ACCESS_RESPONSES
-    }
-)
+    responses={**ENROLLMENT_ACCESS_RESPONSES})
+
 async def get_course_progress(
     course_id: int,
     current_user: User = Depends(get_current_user),
@@ -137,16 +124,14 @@ async def get_course_progress(
     result = await service.get_course_progress(current_user.id, course_id)
     return SuccessResponse(data=result)
 
+
 @router.get(
     "/progress/lecture/{lecture_id}",
     response_model=SuccessResponse[ProgressResponse],
     summary="강의 영상별 진행 조회",
     description="특정 강의 영상의 학습 진행 상태를 조회합니다.",
-    responses={
-        200: {"description": "진행 정보 조회 성공"},
-        **ENROLLMENT_ACCESS_RESPONSES
-    }
-)
+    responses={**ENROLLMENT_ACCESS_RESPONSES})
+
 async def get_lecture_progress(
     lecture_id: int,
     current_user: User = Depends(get_current_user),


### PR DESCRIPTION

## 개요
강의 학습 화면에서 필요한 동영상 시청 정보 저장 및 조회 기능을 구현했습니다.
시청 기록을 기반으로 강의 진행률을 계산하는 로직을 추가했습니다.

## 변경사항
-동영상 시청 기록 저장 API 구현
-재생 위치(초 단위) 저장
-재시청 시 기존 기록 업데이트 처리
-마지막 시청 지점 조회 API 구현
-학습 중인 강의/강의자료에 대한 최신 시청 위치 조회
-강의 진행률 계산 로직 추가
-강의별 전체 재생 길이 대비 누적 시청 시간 기반 진행률 계산
-진행률 저장 및 업데이트


## 관련 이슈
**Closes #58 