### PR TITLE
[FIX] 결제 관련 오류 사항들 수정 완료

### DIFF
--- a/app/routers/admin/payments.py
+++ b/app/routers/admin/payments.py
@@ -82,7 +82,6 @@ async def export_payments(
     service = AdminPaymentService(db)
     items = await service.export_payments(params)
 
-    # CSV 파일 생성
     output = io.StringIO()
     if items:
         fieldnames = [
@@ -94,13 +93,10 @@ async def export_payments(
         writer.writeheader()
 
         for item in items:
-            row = {}
+            row = {field: item[field] for field in fieldnames}
             for field in fieldnames:
-                value = getattr(item, field, None)
-                # datetime 객체를 문자열로 변환
-                if hasattr(value, 'isoformat'):
-                    value = value.isoformat()
-                row[field] = value
+                if hasattr(row[field], 'isoformat'):
+                    row[field] = row[field].isoformat()
             writer.writerow(row)
 
     output.seek(0)

--- a/app/schemas/admin.py
+++ b/app/schemas/admin.py
@@ -1,6 +1,6 @@
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_serializer
 from typing import Optional, List, Any
-from datetime import datetime, date
+from datetime import datetime, date, timezone, timedelta
 from enum import Enum
 
 from app.schemas.course import CategoryType, Difficulty
@@ -253,9 +253,17 @@ class PaymentManagementResponse(BaseModel):
     status: str
     paid_at: Optional[datetime]
     created_at: datetime
-    
+
     class Config:
         from_attributes = True
+
+    @field_serializer('paid_at', 'created_at')
+    def serialize_datetime(self, value: Optional[datetime]) -> Optional[str]:
+        if not value:
+            return None
+        kst = timezone(timedelta(hours=9))
+        utc = value.replace(tzinfo=timezone.utc) if value.tzinfo is None else value
+        return utc.astimezone(kst).isoformat()
 
 # ============= 환불 관리 =============
 class RefundManagementListParams(BaseModel):
@@ -297,6 +305,14 @@ class RefundManagementResponse(BaseModel):
     requested_at: datetime
     processed_at: Optional[datetime]
     admin_note: Optional[str]
+
+    @field_serializer('payment_date', 'requested_at', 'processed_at')
+    def serialize_datetime(self, value: Optional[datetime]) -> Optional[str]:
+        if not value:
+            return None
+        kst = timezone(timedelta(hours=9))
+        utc = value.replace(tzinfo=timezone.utc) if value.tzinfo is None else value
+        return utc.astimezone(kst).isoformat()
 
 # ============= 통계 조회 파라미터 =============
 class StatsQueryParams(BaseModel):

--- a/app/schemas/payment.py
+++ b/app/schemas/payment.py
@@ -1,6 +1,6 @@
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import BaseModel, Field, field_validator, model_validator, field_serializer
 from typing import List, Optional
-from datetime import datetime
+from datetime import datetime, timezone, timedelta
 from enum import Enum
 
 # Enums
@@ -39,20 +39,26 @@ class PaymentResponse(BaseModel):
     user_id: int
     course_id: int
     course_title: str
-    amount: int  # 원(KRW) 단위, 소수점 없음
-    discount_amount: int = 0  # 원(KRW) 단위
-    final_amount: int  # 원(KRW) 단위
+    amount: int
+    discount_amount: int = 0
+    final_amount: int
     payment_method: PaymentMethod
     status: PaymentStatus
     transaction_id: str
     receipt_url: Optional[str]
     paid_at: Optional[datetime]
     created_at: datetime
-    
+
     class Config:
         from_attributes = True
-        # 금액은 정수형 원(KRW) 단위로 저장됩니다.
-        # 예: 50000 = 50,000원
+
+    @field_serializer('paid_at', 'created_at')
+    def serialize_datetime(self, value: Optional[datetime]) -> Optional[str]:
+        if not value:
+            return None
+        kst = timezone(timedelta(hours=9))
+        utc = value.replace(tzinfo=timezone.utc) if value.tzinfo is None else value
+        return utc.astimezone(kst).isoformat()
 
 class PaymentDetailResponse(BaseModel):
     id: int
@@ -70,12 +76,19 @@ class PaymentDetailResponse(BaseModel):
     receipt_url: Optional[str]
     paid_at: Optional[datetime]
     created_at: datetime
-    # 환불 가능 여부
     can_refund: bool = False
-    refund_reason: Optional[str] = None  # 환불 불가 사유
-    
+    refund_reason: Optional[str] = None
+
     class Config:
         from_attributes = True
+
+    @field_serializer('paid_at', 'created_at')
+    def serialize_datetime(self, value: Optional[datetime]) -> Optional[str]:
+        if not value:
+            return None
+        kst = timezone(timedelta(hours=9))
+        utc = value.replace(tzinfo=timezone.utc) if value.tzinfo is None else value
+        return utc.astimezone(kst).isoformat()
 
 class PaymentListParams(BaseModel):
     status: Optional[str] = Field(
@@ -155,13 +168,20 @@ class RefundResponse(BaseModel):
     admin_note: Optional[str]
     requested_at: datetime
     processed_at: Optional[datetime]
-    # 결제 정보
     payment_date: datetime
     course_title: str
     progress_rate: float
-    
+
     class Config:
         from_attributes = True
+
+    @field_serializer('requested_at', 'processed_at', 'payment_date')
+    def serialize_datetime(self, value: Optional[datetime]) -> Optional[str]:
+        if not value:
+            return None
+        kst = timezone(timedelta(hours=9))
+        utc = value.replace(tzinfo=timezone.utc) if value.tzinfo is None else value
+        return utc.astimezone(kst).isoformat()
 
 class RefundCheckResponse(BaseModel):
     can_refund: bool


### PR DESCRIPTION
## 개요
- 결제 내역 내보내기(CSV 다운로드) 기능, 결제/환불 관련 API의 시간대 문제 해결

## 변경사항
### 1. CSV 파일 데이터 채우기 문제 해결
- 파일: bootrun-backend/app/routers/admin/payments.py
- 변경 전: getattr(item, field, None) 사용
- 변경 후: 딕셔너리 comprehension으로 직접 접근
row = {field: item[field] for field in fieldnames}

### 2. 결제/환불 API 시간대(Timezone) 문제 해결
- 문제:
datetime 필드가 UTC(0시간) 형식 반환: 2025-11-17T13:48:26.727Z
실제 한국 시간(KST)보다 9시간 뒤로 표시

- 영향받는 API:
GET /payments (결제 목록)
GET /payments/{payment_id} (결제 상세)
GET /payments/refunds/{refund_id} (환불 상세)
GET /admin/payments (관리자 결제 목록)
GET /admin/payments/refunds (관리자 환불 목록)
해결: Pydantic @field_serializer로 모든 datetime 필드를 UTC → KST(UTC+9)로 변환

## 스크린샷
<img width="2580" height="1496" alt="스크린샷 2025-11-17 224949" src="https://github.com/user-attachments/assets/a5795cad-02cc-4a25-be62-8ec0dc90e595" />
<img width="1332" height="1459" alt="스크린샷 2025-11-17 232611" src="https://github.com/user-attachments/assets/8267a79f-bbc5-4019-a09c-2d0fb153023c" />
<img width="1332" height="1476" alt="스크린샷 2025-11-17 232628" src="https://github.com/user-attachments/assets/f8578933-626a-4346-a014-ac98ca22c51d" />


## 관련 이슈
**Closes #84 #85