### PR TITLE
[FIX] 강의 수정 시 영상 URL 변경에 따른 재생시간 자동 재계산

### DIFF
--- a/app/services/admin_course_service.py
+++ b/app/services/admin_course_service.py
@@ -696,7 +696,7 @@ class AdminCourseService:
                     calculated_duration = await get_video_duration(
                         video_url,
                         video_type.value,
-                        settings.youtube_api_key if settings.youtube_api_key else None
+                        settings.youtube_api_key
                     )
                     if calculated_duration:
                         update_data['duration_seconds'] = calculated_duration

--- a/app/services/admin_course_service.py
+++ b/app/services/admin_course_service.py
@@ -681,22 +681,20 @@ class AdminCourseService:
         # 업데이트할 필드만 수정
         update_data = data.model_dump(exclude_unset=True)
 
-        # video_url이 변경되고 duration_seconds가 명시되지 않은 경우 자동 계산
-        if 'video_url' in update_data and 'duration_seconds' not in update_data:
-            new_video_url = update_data['video_url']
+        # video_url 또는 video_type이 변경되고 duration_seconds가 명시되지 않은 경우 자동 계산
+        if ('video_url' in update_data or 'video_type' in update_data) and 'duration_seconds' not in update_data:
+            video_url = update_data.get('video_url', lecture.video_url)
+            video_type = update_data.get('video_type', lecture.video_type)
 
             # 빈 문자열이거나 공백만 있는 경우 0으로 설정
-            if not new_video_url or not new_video_url.strip():
+            if not video_url or not video_url.strip():
                 logger.info(f"영상 URL이 비어있어 재생시간을 0으로 설정합니다.")
                 update_data['duration_seconds'] = 0
             else:
-                # video_type 결정 (업데이트 데이터에 있으면 사용, 없으면 기존 값 사용)
-                video_type = update_data.get('video_type', lecture.video_type)
-
-                logger.info(f"영상 URL이 변경되어 재생시간 자동 계산 시도: {new_video_url}")
+                logger.info(f"영상 정보가 변경되어 재생시간 자동 계산 시도: {video_url}")
                 try:
                     calculated_duration = await get_video_duration(
-                        new_video_url,
+                        video_url,
                         video_type.value,
                         settings.youtube_api_key if settings.youtube_api_key else None
                     )

--- a/app/services/admin_course_service.py
+++ b/app/services/admin_course_service.py
@@ -680,6 +680,34 @@ class AdminCourseService:
 
         # 업데이트할 필드만 수정
         update_data = data.model_dump(exclude_unset=True)
+
+        # video_url이 변경되고 duration_seconds가 명시되지 않은 경우 자동 계산
+        if 'video_url' in update_data and 'duration_seconds' not in update_data:
+            new_video_url = update_data['video_url']
+
+            # 빈 문자열이거나 공백만 있는 경우 0으로 설정
+            if not new_video_url or not new_video_url.strip():
+                logger.info(f"영상 URL이 비어있어 재생시간을 0으로 설정합니다.")
+                update_data['duration_seconds'] = 0
+            else:
+                # video_type 결정 (업데이트 데이터에 있으면 사용, 없으면 기존 값 사용)
+                video_type = update_data.get('video_type', lecture.video_type)
+
+                logger.info(f"영상 URL이 변경되어 재생시간 자동 계산 시도: {new_video_url}")
+                try:
+                    calculated_duration = await get_video_duration(
+                        new_video_url,
+                        video_type.value,
+                        settings.youtube_api_key if settings.youtube_api_key else None
+                    )
+                    if calculated_duration:
+                        update_data['duration_seconds'] = calculated_duration
+                        logger.info(f"재생시간 자동 계산 성공: {calculated_duration}초")
+                    else:
+                        logger.warning("재생시간 자동 계산 실패, 기존 값 유지")
+                except Exception as e:
+                    logger.error(f"재생시간 자동 계산 중 오류: {e}, 기존 값 유지")
+
         for field, value in update_data.items():
             setattr(lecture, field, value)
 


### PR DESCRIPTION
## 개요
  - 강의 수정 API에서 YouTube URL 변경 시 재생시간이 자동으로 재계산되지 않는      
  버그 수정

  ## 변경사항
  - `update_lecture` 함수에 `video_url` 변경 감지 로직 추가
  - YouTube URL을 빈 값으로 변경 시 재생시간 0초로 자동 설정
  - 다른 YouTube URL로 변경 시 YouTube API를 통한 재생시간 자동 계산
  - `video_type` 변경 시에도 올바른 타입으로 재생시간 재계산
  - 강의 전체 재생시간(`total_duration`) 자동 업데이트

  ## 관련 이슈
  **Closes #107 